### PR TITLE
feat: JSONスキーマとデータアクセス層を整備

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
       },
@@ -210,6 +212,10 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.8.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-GM9c0cWWR8Ga7//Ves/9KRgTS8nLausCkP3CGiFLrnwA2CDUluXgaQqvrULoR2Ujrd/mz/lkX87F5BHFsNr5sQ=="],
 
     "browserslist": ["browserslist@4.26.3", "", { "dependencies": { "baseline-browser-mapping": "^2.8.9", "caniuse-lite": "^1.0.30001746", "electron-to-chromium": "^1.5.227", "node-releases": "^2.0.21", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w=="],
@@ -228,6 +234,10 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -237,6 +247,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -259,6 +271,8 @@
     "react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "rollup": ["rollup@4.52.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.4", "@rollup/rollup-android-arm64": "4.52.4", "@rollup/rollup-darwin-arm64": "4.52.4", "@rollup/rollup-darwin-x64": "4.52.4", "@rollup/rollup-freebsd-arm64": "4.52.4", "@rollup/rollup-freebsd-x64": "4.52.4", "@rollup/rollup-linux-arm-gnueabihf": "4.52.4", "@rollup/rollup-linux-arm-musleabihf": "4.52.4", "@rollup/rollup-linux-arm64-gnu": "4.52.4", "@rollup/rollup-linux-arm64-musl": "4.52.4", "@rollup/rollup-linux-loong64-gnu": "4.52.4", "@rollup/rollup-linux-ppc64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-musl": "4.52.4", "@rollup/rollup-linux-s390x-gnu": "4.52.4", "@rollup/rollup-linux-x64-gnu": "4.52.4", "@rollup/rollup-linux-x64-musl": "4.52.4", "@rollup/rollup-openharmony-arm64": "4.52.4", "@rollup/rollup-win32-arm64-msvc": "4.52.4", "@rollup/rollup-win32-ia32-msvc": "4.52.4", "@rollup/rollup-win32-x64-gnu": "4.52.4", "@rollup/rollup-win32-x64-msvc": "4.52.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ=="],
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,18 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "validate:schema": "bun src/scripts/validate-schemas.ts",
+    "demo:io": "bun src/scripts/io-demo.ts",
+    "demo:workspace": "bun src/scripts/workspace-demo.ts"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/src/lib/data/workspaceService.ts
+++ b/src/lib/data/workspaceService.ts
@@ -1,0 +1,52 @@
+import { join } from 'node:path';
+import type { WorkspaceFile, BookFile } from '../../types/schema';
+import {
+  readWorkspaceFile,
+  writeWorkspaceFile,
+  readBookFile,
+  writeBookFile
+} from '../fs/jsonStore';
+
+export interface LoadedWorkspace {
+  filePath: string;
+  data: WorkspaceFile;
+}
+
+export interface LoadedBook {
+  filePath: string;
+  data: BookFile;
+}
+
+export interface WorkspaceSnapshot {
+  workspace: LoadedWorkspace;
+  books: LoadedBook[];
+}
+
+export const loadWorkspace = async (workspacePath: string): Promise<WorkspaceSnapshot> => {
+  const workspaceData = await readWorkspaceFile(workspacePath);
+
+  const books = await Promise.all(
+    workspaceData.books.map(async (bookRef) => {
+      const bookPath = join(workspacePath, '..', bookRef.dataPath);
+      const data = await readBookFile(bookPath);
+      return { filePath: bookPath, data } as LoadedBook;
+    })
+  );
+
+  return {
+    workspace: { filePath: workspacePath, data: workspaceData },
+    books
+  };
+};
+
+export const saveWorkspace = async (
+  snapshot: WorkspaceSnapshot,
+  options?: { saveBooks?: boolean }
+): Promise<void> => {
+  const { workspace, books } = snapshot;
+  await writeWorkspaceFile(workspace.filePath, workspace.data);
+
+  if (options?.saveBooks ?? true) {
+    await Promise.all(books.map((book) => writeBookFile(book.filePath, book.data)));
+  }
+};

--- a/src/lib/fs/jsonStore.ts
+++ b/src/lib/fs/jsonStore.ts
@@ -1,0 +1,59 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+import type { WorkspaceFile, BookFile } from '../../types/schema';
+import {
+  assertWorkspaceFile,
+  assertBookFile,
+  validateWorkspaceFile,
+  validateBookFile
+} from '../schemaValidator';
+
+const ensureDir = async (path: string) => {
+  await mkdir(path, { recursive: true });
+};
+
+const parseJson = <T>(raw: string): T => {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(`JSON parse error: ${(err as Error).message}`);
+  }
+};
+
+export const readWorkspaceFile = async (filePath: string): Promise<WorkspaceFile> => {
+  const raw = await readFile(filePath, 'utf-8');
+  const data = parseJson<unknown>(raw);
+  assertWorkspaceFile(data);
+  return data;
+};
+
+export const writeWorkspaceFile = async (
+  filePath: string,
+  workspace: WorkspaceFile
+): Promise<void> => {
+  const { valid, errors } = validateWorkspaceFile(workspace);
+  if (!valid) {
+    throw new Error(`Workspace payload invalid.\n${errors.join('\n')}`);
+  }
+
+  await ensureDir(dirname(filePath));
+  await writeFile(filePath, `${JSON.stringify(workspace, null, 2)}\n`, 'utf-8');
+};
+
+export const readBookFile = async (filePath: string): Promise<BookFile> => {
+  const raw = await readFile(filePath, 'utf-8');
+  const data = parseJson<unknown>(raw);
+  assertBookFile(data);
+  return data;
+};
+
+export const writeBookFile = async (filePath: string, book: BookFile): Promise<void> => {
+  const { valid, errors } = validateBookFile(book);
+  if (!valid) {
+    throw new Error(`Book payload invalid.\n${errors.join('\n')}`);
+  }
+
+  await ensureDir(dirname(filePath));
+  await writeFile(filePath, `${JSON.stringify(book, null, 2)}\n`, 'utf-8');
+};

--- a/src/lib/schemaValidator.ts
+++ b/src/lib/schemaValidator.ts
@@ -1,0 +1,46 @@
+import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import workspaceSchema from '../schemas/workspace.schema.json';
+import bookSchema from '../schemas/book.schema.json';
+import type { WorkspaceFile, BookFile } from '../types/schema';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+
+const workspaceValidator: ValidateFunction = ajv.compile(workspaceSchema);
+const bookValidator: ValidateFunction = ajv.compile(bookSchema);
+
+const formatErrors = (errors: ErrorObject[] | null | undefined): string[] =>
+  (errors ?? []).map((err) => {
+    const path = err.instancePath || '(root)';
+    return `${path} ${err.message ?? ''}`.trim();
+  });
+
+export interface ValidationResult<T> {
+  valid: data is T;
+  errors: string[];
+}
+
+export const validateWorkspaceFile = (data: unknown): ValidationResult<WorkspaceFile> => {
+  const valid = workspaceValidator(data) as boolean;
+  return { valid, errors: valid ? [] : formatErrors(workspaceValidator.errors) };
+};
+
+export const validateBookFile = (data: unknown): ValidationResult<BookFile> => {
+  const valid = bookValidator(data) as boolean;
+  return { valid, errors: valid ? [] : formatErrors(bookValidator.errors) };
+};
+
+export const assertWorkspaceFile = (data: unknown): asserts data is WorkspaceFile => {
+  const result = validateWorkspaceFile(data);
+  if (!result.valid) {
+    throw new Error(`Invalid workspace file.\n${result.errors.join('\n')}`);
+  }
+};
+
+export const assertBookFile = (data: unknown): asserts data is BookFile => {
+  const result = validateBookFile(data);
+  if (!result.valid) {
+    throw new Error(`Invalid book file.\n${result.errors.join('\n')}`);
+  }
+};

--- a/src/samples/sampleData.ts
+++ b/src/samples/sampleData.ts
@@ -1,0 +1,66 @@
+import type { BookFile, WorkspaceFile } from '../types/schema';
+
+export const sampleWorkspace: WorkspaceFile = {
+  schemaVersion: '1.0.0',
+  workspace: {
+    id: 'workspace-001',
+    name: 'Sample Workspace',
+    createdAt: '2025-02-14T08:15:00.000Z',
+    updatedAt: '2025-02-14T09:30:00.000Z',
+    settings: {
+      theme: 'dark',
+      sidebarWidth: 280,
+      recentBookIds: ['book-001'],
+      recentSheetIds: ['sheet-001']
+    }
+  },
+  folders: [
+    { id: 'root', name: 'Root', parentId: null, order: 0 },
+    { id: 'folder-2025', name: '2025年度', parentId: 'root', order: 1 }
+  ],
+  books: [
+    {
+      id: 'book-001',
+      name: 'プロジェクト管理.json',
+      folderId: 'root',
+      order: 0,
+      dataPath: 'books/book-001.json',
+      thumbPath: 'thumbs/book-001.png',
+      activeSheetId: 'sheet-001',
+      createdAt: '2025-02-14T08:30:00.000Z',
+      updatedAt: '2025-02-14T09:20:00.000Z'
+    }
+  ]
+};
+
+export const sampleBook: BookFile = {
+  schemaVersion: '1.0.0',
+  book: {
+    id: 'book-001',
+    name: 'プロジェクト管理',
+    createdAt: '2025-02-14T08:30:00.000Z',
+    updatedAt: '2025-02-14T09:20:00.000Z',
+    properties: {
+      defaultFormat: 'plain',
+      locked: false
+    }
+  },
+  sheets: [
+    {
+      id: 'sheet-001',
+      name: 'ダッシュボード',
+      gridSize: { rows: 100, cols: 26 },
+      settings: { locked: false },
+      rows: {
+        '1': {
+          A: { value: '売上', type: 'string' },
+          C: { value: '経費', type: 'string' }
+        },
+        '2': {
+          A: { value: 100, type: 'number', format: 'currency' },
+          C: { value: 30, type: 'number', format: 'currency' }
+        }
+      }
+    }
+  ]
+};

--- a/src/schemas/book.schema.json
+++ b/src/schemas/book.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/book.json",
+  "title": "Book",
+  "type": "object",
+  "required": ["schemaVersion", "book", "sheets"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "book": {
+      "type": "object",
+      "required": ["id", "name", "createdAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "createdAt": { "$ref": "#/$defs/dateTime" },
+        "updatedAt": { "$ref": "#/$defs/dateTime" },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "defaultFormat": { "type": "string" },
+            "locked": { "type": "boolean" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "sheets": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/sheet" },
+      "default": []
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{4,64}$"
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dateTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sheet": {
+      "type": "object",
+      "required": ["id", "name", "gridSize", "rows"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "gridSize": {
+          "type": "object",
+          "required": ["rows", "cols"],
+          "properties": {
+            "rows": { "type": "integer", "minimum": 1 },
+            "cols": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": false
+        },
+        "settings": {
+          "type": "object",
+          "properties": {
+            "locked": { "type": "boolean" },
+            "tabColor": { "type": "string" }
+          },
+          "additionalProperties": true
+        },
+        "rows": {
+          "type": "object",
+          "patternProperties": {
+            "^[1-9][0-9]*$": { "$ref": "#/$defs/row" }
+          },
+          "additionalProperties": false,
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "row": {
+      "type": "object",
+      "patternProperties": {
+        "^[A-Z]+$": { "$ref": "#/$defs/cell" }
+      },
+      "additionalProperties": false,
+      "default": {}
+    },
+    "cell": {
+      "type": "object",
+      "required": ["value", "type"],
+      "properties": {
+        "value": {
+          "type": ["string", "number", "boolean", "null"]
+        },
+        "type": {
+          "enum": ["string", "number", "boolean", "date", "formula", "empty"]
+        },
+        "format": { "type": "string" },
+        "formula": { "type": "string" },
+        "comment": { "type": "string" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/schemas/workspace.schema.json
+++ b/src/schemas/workspace.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/workspace.json",
+  "title": "Workspace",
+  "type": "object",
+  "required": ["schemaVersion", "workspace", "folders", "books"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "workspace": {
+      "type": "object",
+      "required": ["id", "name", "createdAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "createdAt": { "$ref": "#/$defs/dateTime" },
+        "updatedAt": { "$ref": "#/$defs/dateTime" },
+        "settings": {
+          "type": "object",
+          "properties": {
+            "theme": { "enum": ["light", "dark", "system"] },
+            "sidebarWidth": { "type": "integer", "minimum": 160, "maximum": 640 },
+            "recentBookIds": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/id" },
+              "uniqueItems": true,
+              "maxItems": 20
+            },
+            "recentSheetIds": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/id" },
+              "uniqueItems": true,
+              "maxItems": 20
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "folders": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/folder" },
+      "default": []
+    },
+    "books": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/bookRef" },
+      "default": []
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{4,64}$"
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dateTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "folder": {
+      "type": "object",
+      "required": ["id", "name", "order"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "parentId": {
+          "oneOf": [
+            { "$ref": "#/$defs/id" },
+            { "type": "null" }
+          ]
+        },
+        "order": { "type": "number" },
+        "metadata": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": false
+    },
+    "bookRef": {
+      "type": "object",
+      "required": ["id", "name", "dataPath", "order", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "folderId": {
+          "oneOf": [
+            { "$ref": "#/$defs/id" },
+            { "type": "null" }
+          ]
+        },
+        "order": { "type": "number" },
+        "dataPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "thumbPath": {
+          "type": "string"
+        },
+        "activeSheetId": { "$ref": "#/$defs/id" },
+        "createdAt": { "$ref": "#/$defs/dateTime" },
+        "updatedAt": { "$ref": "#/$defs/dateTime" },
+        "metadata": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/scripts/io-demo.ts
+++ b/src/scripts/io-demo.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import {
+  writeWorkspaceFile,
+  readWorkspaceFile,
+  writeBookFile,
+  readBookFile
+} from '../lib/fs/jsonStore';
+import { sampleWorkspace, sampleBook } from '../samples/sampleData';
+
+const main = async () => {
+  const baseDir = await mkdtemp(join(tmpdir(), 'sheet-up-'));
+  const workspacePath = join(baseDir, 'workspace.json');
+  const bookPath = join(baseDir, 'books', 'book-001.json');
+
+  await writeWorkspaceFile(workspacePath, sampleWorkspace);
+  await writeBookFile(bookPath, sampleBook);
+
+  const loadedWorkspace = await readWorkspaceFile(workspacePath);
+  const loadedBook = await readBookFile(bookPath);
+
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.log('Workspace name:', loadedWorkspace.workspace.name);
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.log('Sheets count:', loadedBook.sheets.length);
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.log('Data stored under:', baseDir);
+};
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.error('I/O demo failed:', err);
+  process.exitCode = 1;
+});

--- a/src/scripts/validate-schemas.ts
+++ b/src/scripts/validate-schemas.ts
@@ -1,0 +1,11 @@
+import { assertBookFile, assertWorkspaceFile } from '../lib/schemaValidator';
+import { sampleBook, sampleWorkspace } from '../samples/sampleData';
+
+const main = () => {
+  assertWorkspaceFile(sampleWorkspace);
+  assertBookFile(sampleBook);
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.log('Sample workspace and book data passed schema validation.');
+};
+
+main();

--- a/src/scripts/workspace-demo.ts
+++ b/src/scripts/workspace-demo.ts
@@ -1,0 +1,38 @@
+import { join } from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { writeWorkspaceFile, writeBookFile } from '../lib/fs/jsonStore';
+import { sampleWorkspace, sampleBook } from '../samples/sampleData';
+import { loadWorkspace, saveWorkspace } from '../lib/data/workspaceService';
+
+const main = async () => {
+  const baseDir = await mkdtemp(join(tmpdir(), 'sheet-up-ws-'));
+  const workspacePath = join(baseDir, 'workspace.json');
+  const bookPath = join(baseDir, 'books', 'book-001.json');
+
+  // 初期データを保存
+  await writeWorkspaceFile(workspacePath, sampleWorkspace);
+  await writeBookFile(bookPath, sampleBook);
+
+  // ロードして書き換え
+  const snapshot = await loadWorkspace(workspacePath);
+  snapshot.workspace.data.workspace.name = 'Updated Workspace Name';
+  snapshot.books[0].data.book.name = 'Updated Book Name';
+
+  await saveWorkspace(snapshot);
+
+  const reloaded = await loadWorkspace(workspacePath);
+
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.log('Workspace name:', reloaded.workspace.data.workspace.name);
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.log('Book name:', reloaded.books[0].data.book.name);
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.log('Snapshot saved under:', baseDir);
+};
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console -- CLI feedback
+  console.error('Workspace demo failed:', err);
+  process.exitCode = 1;
+});

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,0 +1,100 @@
+// Core data structures shared between workspace.json and books/{bookId}.json
+export type EntityId = string;
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+export interface WorkspaceSettings {
+  theme?: ThemePreference;
+  sidebarWidth?: number;
+  recentBookIds?: EntityId[];
+  recentSheetIds?: EntityId[];
+  [key: string]: unknown;
+}
+
+export interface WorkspaceMeta {
+  id: EntityId;
+  name: string;
+  createdAt: string; // ISO8601 timestamp
+  updatedAt?: string;
+  settings?: WorkspaceSettings;
+}
+
+export interface FolderMeta {
+  id: EntityId;
+  name: string;
+  parentId?: EntityId | null;
+  order: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BookReference {
+  id: EntityId;
+  name: string;
+  folderId?: EntityId | null;
+  order: number;
+  dataPath: string;
+  thumbPath?: string;
+  activeSheetId?: EntityId;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface WorkspaceFile {
+  schemaVersion: string;
+  workspace: WorkspaceMeta;
+  folders: FolderMeta[];
+  books: BookReference[];
+}
+
+export interface GridSize {
+  rows: number;
+  cols: number;
+}
+
+export type CellType = 'string' | 'number' | 'boolean' | 'date' | 'formula' | 'empty';
+
+export interface CellData {
+  value: string | number | boolean | null;
+  type: CellType;
+  format?: string;
+  formula?: string;
+  comment?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type RowData = Record<string, CellData>;
+
+export interface SheetSettings {
+  locked?: boolean;
+  tabColor?: string;
+  [key: string]: unknown;
+}
+
+export interface SheetData {
+  id: EntityId;
+  name: string;
+  gridSize: GridSize;
+  settings?: SheetSettings;
+  rows: Record<string, RowData>;
+}
+
+export interface BookProperties {
+  defaultFormat?: string;
+  locked?: boolean;
+  [key: string]: unknown;
+}
+
+export interface BookMeta {
+  id: EntityId;
+  name: string;
+  createdAt: string;
+  updatedAt?: string;
+  properties?: BookProperties;
+}
+
+export interface BookFile {
+  schemaVersion: string;
+  book: BookMeta;
+  sheets: SheetData[];
+}


### PR DESCRIPTION
## 背景
- ワークスペース/ブックデータの仕様が固まったため、バリデーションと入出力の仕組みを整備したい。

## 変更内容
- Workspace/Book 用の TypeScript 型と JSON Schema を追加
- AJV + ajv-formats を用いたスキーマバリデータを実装
- JSON 読み書きユーティリティとワークスペースサービスレイヤを追加
- サンプルデータと検証スクリプト (`validate:schema`, `demo:io`, `demo:workspace`) を追加
- 依存関係に `ajv`, `ajv-formats` を導入

## 動作確認
- `bun run validate:schema` を実行し、サンプルデータのバリデーション成功を確認
- `bun run demo:io` を実行し、JSON の書き出し/読み込みが動作することを確認
- `bun run demo:workspace` を実行し、ワークスペースロード/保存が動作することを確認

## 残課題
- AGENTS.md のルール更新は別途コミット予定
- React/Tauri からの実際の呼び出しはこれから実装
