### PR TITLE
fix: ダイアログ権限をcapabilityに追加

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "dialog:default"
   ]
 }


### PR DESCRIPTION
## 背景／目的
- Issue #28 で報告された通り、ワークスペースを開く際のフォルダ選択ダイアログが表示されない不具合があった。
- Tauri 2 の権限モデルにより、capability に `dialog:default` を明示しないとダイアログがブロックされるため、権限を付与する。

## 主要な変更点
- `src-tauri/capabilities/default.json` に `dialog:default` を追加。

## 動作確認
- `bun run build`
- Tauri アプリで「ワークスペースを開く」を実行し、フォルダ選択ダイアログが表示されることを確認。

Closes #28