### PR TITLE
feat: アプリ内から新規ブックを作成できるようにする

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -143,6 +143,20 @@ button {
   border: 1px dashed rgba(249, 250, 251, 0.3);
   background: transparent;
   color: rgba(249, 250, 251, 0.7);
+}
+
+.sidebar__actionButton:not(:disabled) {
+  cursor: pointer;
+  border-style: solid;
+  border-color: rgba(249, 250, 251, 0.5);
+}
+
+.sidebar__actionButton:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #f9fafb;
+}
+
+.sidebar__actionButton:disabled {
   cursor: not-allowed;
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ interface SidebarProps {
   selectedSheetId?: string | null;
   onSelectBook: (bookId: string) => void;
   onSelectSheet: (bookId: string, sheetId: string) => void;
+  onCreateBook?: () => void;
 }
 
 const trimExtension = (name: string): string => name.replace(/\.json$/i, '');
@@ -18,11 +19,16 @@ const Sidebar: FC<SidebarProps> = ({
   selectedBookId,
   selectedSheetId,
   onSelectBook,
-  onSelectSheet
+  onSelectSheet,
+  onCreateBook
 }) => {
   const booksById = useMemo(() => new Map(books.map((book) => [book.book.id, book])), [books]);
   const workspaceMeta = workspace?.workspace;
   const workspaceBooks = workspace?.books ?? [];
+  const createDisabled = !workspace || !onCreateBook;
+  const createTitle = createDisabled
+    ? 'ワークスペースを開いてから新規ブックを作成できます'
+    : '新しいブックを追加';
 
   return (
     <aside className="sidebar">
@@ -82,7 +88,13 @@ const Sidebar: FC<SidebarProps> = ({
         </ul>
       </nav>
       <div className="sidebar__footer">
-        <button type="button" className="sidebar__actionButton" disabled>
+        <button
+          type="button"
+          className="sidebar__actionButton"
+          disabled={createDisabled}
+          onClick={onCreateBook}
+          title={createTitle}
+        >
           + 新規ブック
         </button>
       </div>

--- a/src/lib/workspace/bookFactory.ts
+++ b/src/lib/workspace/bookFactory.ts
@@ -1,0 +1,140 @@
+import type { BookFile, BookReference, WorkspaceFile } from '../../types/schema';
+import type { LoadedFile, WorkspaceSnapshot } from '../../types/workspaceSnapshot';
+
+const BOOKS_DIR = 'books';
+const DEFAULT_SHEET_NAME = 'シート1';
+const DEFAULT_ROWS = 100;
+const DEFAULT_COLS = 26;
+
+const normalizeName = (name: string): string => name.trim();
+
+const hasBackslash = (path: string): boolean => path.includes('\\');
+
+const normalizeSeparators = (value: string): string => value.replace(/\\/g, '/');
+
+const toSystemSeparators = (value: string, useBackslash: boolean): string =>
+  useBackslash ? value.replace(/\//g, '\\') : value;
+
+const resolveWorkspaceDir = (workspacePath: string): { normalized: string; useBackslash: boolean } => {
+  const useBackslash = hasBackslash(workspacePath);
+  const normalized = normalizeSeparators(workspacePath);
+  const segments = normalized.split('/');
+  segments.pop();
+  return { normalized: segments.join('/'), useBackslash };
+};
+
+const joinWorkspacePath = (
+  workspaceDir: { normalized: string; useBackslash: boolean },
+  relative: string
+): string => {
+  const normalizedRelative = normalizeSeparators(relative).replace(/^\//, '');
+  const combined = `${workspaceDir.normalized}/${normalizedRelative}`.replace(/\/+/, '/');
+  return toSystemSeparators(combined, workspaceDir.useBackslash);
+};
+
+const generateId = (prefix: string): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  const random = Math.random().toString(36).slice(2, 10);
+  return `${prefix}-${Date.now().toString(36)}-${random}`;
+};
+
+interface BuildBookResult {
+  workspaceData: WorkspaceFile;
+  bookReference: BookReference;
+  loadedBook: LoadedFile<BookFile>;
+  defaultSheetId: string;
+}
+
+export const buildNewBookSnapshot = (
+  nameInput: string,
+  snapshot: WorkspaceSnapshot
+): BuildBookResult => {
+  const trimmedName = normalizeName(nameInput);
+  if (!trimmedName) {
+    throw new Error('ブック名が入力されていません。');
+  }
+
+  const now = new Date().toISOString();
+  const bookId = generateId('book');
+  const sheetId = generateId('sheet');
+
+  const workspaceDir = resolveWorkspaceDir(snapshot.workspace.filePath);
+  const dataPath = `${BOOKS_DIR}/${bookId}.json`;
+  const absoluteBookPath = joinWorkspacePath(workspaceDir, dataPath);
+
+  const bookFile: BookFile = {
+    schemaVersion: snapshot.workspace.data.schemaVersion,
+    book: {
+      id: bookId,
+      name: trimmedName,
+      createdAt: now,
+      updatedAt: now,
+      properties: {
+        defaultFormat: 'plain',
+        locked: false
+      }
+    },
+    sheets: [
+      {
+        id: sheetId,
+        name: DEFAULT_SHEET_NAME,
+        gridSize: { rows: DEFAULT_ROWS, cols: DEFAULT_COLS },
+        settings: {},
+        rows: {}
+      }
+    ]
+  };
+
+  const nextOrder = snapshot.workspace.data.books.length;
+
+  const bookReference: BookReference = {
+    id: bookId,
+    name: `${bookId}.json`,
+    folderId: null,
+    order: nextOrder,
+    dataPath,
+    activeSheetId: sheetId,
+    createdAt: now,
+    updatedAt: now
+  };
+
+  const previousWorkspace = snapshot.workspace.data;
+  const previousSettings = previousWorkspace.workspace.settings ?? {};
+
+  const updatedRecentBooks = [
+    bookId,
+    ...((previousSettings.recentBookIds ?? []).filter((id) => id !== bookId))
+  ].slice(0, 20);
+  const updatedRecentSheets = [
+    sheetId,
+    ...((previousSettings.recentSheetIds ?? []).filter((id) => id !== sheetId))
+  ].slice(0, 20);
+
+  const workspaceData: WorkspaceFile = {
+    ...previousWorkspace,
+    workspace: {
+      ...previousWorkspace.workspace,
+      updatedAt: now,
+      settings: {
+        ...previousSettings,
+        recentBookIds: updatedRecentBooks,
+        recentSheetIds: updatedRecentSheets
+      }
+    },
+    books: [...previousWorkspace.books, bookReference]
+  };
+
+  const loadedBook: LoadedFile<BookFile> = {
+    filePath: absoluteBookPath,
+    data: bookFile
+  };
+
+  return {
+    workspaceData,
+    bookReference,
+    loadedBook,
+    defaultSheetId: sheetId
+  };
+};


### PR DESCRIPTION
## 背景／目的
- Issue #9 の対応として、アプリ内からブックを追加できるようにする。
- ワークスペースの永続化を前提に、UI からブックを生成して保存するフローを整備する。

## 主要な変更点
- `buildNewBookSnapshot` を追加し、新規ブック＋初期シートのテンプレート生成とファイルパス解決を実装。
- App から新規ブック作成ハンドラを組み込み、追加後にスナップショットと保存処理を更新。
- サイドバー「+ 新規ブック」ボタンを有効化し、ワークスペース未ロード時のみ無効化されるように調整。

## 動作確認
- `bun run build`
- Tauri 実行時にワークスペースを開き、「+ 新規ブック」を押すとブックが作成されることを手動確認。

Closes #9