### PR TITLE
feat: アプリ内でシートを追加できるようにする

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -103,6 +103,28 @@ button {
   gap: 2px;
 }
 
+.sidebar__sheetAddButton {
+  width: 100%;
+  padding: 4px 6px;
+  border: none;
+  border-radius: 6px;
+  background: rgba(249, 250, 251, 0.08);
+  color: rgba(249, 250, 251, 0.8);
+  font-size: 0.8rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sidebar__sheetAddButton:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: #f9fafb;
+}
+
+.sidebar__sheetAddButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .sidebar__sheetButton {
   width: 100%;
   padding: 4px 6px;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ interface SidebarProps {
   onSelectBook: (bookId: string) => void;
   onSelectSheet: (bookId: string, sheetId: string) => void;
   onCreateBook?: () => void;
+  onCreateSheet?: (bookId: string) => void;
 }
 
 const trimExtension = (name: string): string => name.replace(/\.json$/i, '');
@@ -20,7 +21,8 @@ const Sidebar: FC<SidebarProps> = ({
   selectedSheetId,
   onSelectBook,
   onSelectSheet,
-  onCreateBook
+  onCreateBook,
+  onCreateSheet
 }) => {
   const booksById = useMemo(() => new Map(books.map((book) => [book.book.id, book])), [books]);
   const workspaceMeta = workspace?.workspace;
@@ -74,6 +76,17 @@ const Sidebar: FC<SidebarProps> = ({
                     {book.sheets.length === 0 && (
                       <li className="sidebar__empty">シートがありません</li>
                     )}
+                    <li>
+                      <button
+                        type="button"
+                        className="sidebar__sheetAddButton"
+                        disabled={!onCreateSheet}
+                        onClick={() => onCreateSheet?.(bookRef.id)}
+                        title="このブックに新しいシートを追加"
+                      >
+                        + 新しいシート
+                      </button>
+                    </li>
                   </ul>
                 ) : null}
               </li>

--- a/src/lib/workspace/sheetFactory.ts
+++ b/src/lib/workspace/sheetFactory.ts
@@ -1,0 +1,56 @@
+import type { BookFile, SheetData } from '../../types/schema';
+
+const DEFAULT_SHEET_NAME = '新しいシート';
+const DEFAULT_ROWS = 100;
+const DEFAULT_COLS = 26;
+
+const generateId = (prefix: string): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  const random = Math.random().toString(36).slice(2, 10);
+  return `${prefix}-${Date.now().toString(36)}-${random}`;
+};
+
+const createDefaultSheetName = (book: BookFile): string => {
+  const existing = new Set(book.sheets.map((sheet) => sheet.name));
+  if (!existing.has(DEFAULT_SHEET_NAME)) {
+    return DEFAULT_SHEET_NAME;
+  }
+  let counter = 2;
+  while (existing.has(`${DEFAULT_SHEET_NAME} (${counter})`)) {
+    counter += 1;
+  }
+  return `${DEFAULT_SHEET_NAME} (${counter})`;
+};
+
+const createEmptySheet = (name: string): SheetData => ({
+  id: generateId('sheet'),
+  name,
+  gridSize: { rows: DEFAULT_ROWS, cols: DEFAULT_COLS },
+  settings: {},
+  rows: {}
+});
+
+export const buildNewSheetSnapshot = (
+  bookFile: BookFile
+): { bookFile: BookFile; defaultSheetId: string } => {
+  const name = createDefaultSheetName(bookFile);
+  const newSheet = createEmptySheet(name);
+
+  const sheets = [...bookFile.sheets, newSheet];
+
+  const now = new Date().toISOString();
+
+  return {
+    bookFile: {
+      ...bookFile,
+      book: {
+        ...bookFile.book,
+        updatedAt: now
+      },
+      sheets
+    },
+    defaultSheetId: newSheet.id
+  };
+};


### PR DESCRIPTION
## 背景／目的
- Issue #13 に沿って、ブック内に新しいシートを追加できるようにする。
- シート作成後すぐにアクティブ化・保存できるよう、永続化フローまで整備する。

## 主要な変更点
- `buildNewSheetSnapshot` を追加し、シートID生成・初期構造・更新日時の付与を共通化。
- App からシート追加ハンドラを実装し、スナップショット更新／保存／アクティブシート切り替えまで実行。
- サイドバーに「+ 新しいシート」ボタンを追加し、ブック選択中に常にシートを追加できるようにした。

## 動作確認
- `bun run build`
- 実アプリでワークスペースを開き、ブック内の「+ 新しいシート」からシートが追加・保存されることを手動確認。

Closes #13