### PR TITLE
chore: スキーマ検証とI/OテストのCIを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Validate JSON schema
+        run: bun run validate:schema
+
+      - name: Test JSON I/O round trip
+        run: bun run demo:io
+
+      - name: Test workspace load/save demo
+        run: bun run demo:workspace


### PR DESCRIPTION
## 背景／目的
- Issue #23 に沿って、JSON スキーマ検証と I/O デモスクリプトを CI で自動実行する。
- 図らずもバリデーションが壊れてしまうことを防ぎ、PR で早期に検知できるようにする。

## 主要な変更点
- GitHub Actions で Bun をセットアップし、以下のスクリプトを実行するワークフロー `ci.yml` を追加。
  - `bun run validate:schema`
  - `bun run demo:io`
  - `bun run demo:workspace`

## 動作確認
- GitHub Actions のワークフローファイル追加のみのため、ローカルで `bun run validate:schema` など既存スクリプトを再確認。

Closes #23