### PR TITLE
feat: セル範囲選択とコピー＆ペーストを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -396,7 +396,15 @@ button {
 .sheet-grid__cell--selected {
   outline: 2px solid #2563eb;
   outline-offset: -2px;
-  background: rgba(37, 99, 235, 0.08);
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.sheet-grid__cell--inRange {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.sheet-grid__table tbody tr:nth-child(even) .sheet-grid__cell--inRange {
+  background: rgba(37, 99, 235, 0.15);
 }
 
 .sheet-grid__cell--editing {

--- a/src/components/SheetGrid.tsx
+++ b/src/components/SheetGrid.tsx
@@ -4,14 +4,17 @@ import {
   useMemo,
   useRef,
   useState,
+  type ClipboardEvent,
   type FC,
-  type KeyboardEvent
+  type KeyboardEvent,
+  type MouseEvent
 } from 'react';
 import type { SheetData } from '../types/schema';
 
 interface SheetGridProps {
   sheet: SheetData | null;
   onCommitCell?: (rowKey: string, columnKey: string, value: string) => void;
+  onCommitCells?: (updates: Array<{ rowKey: string; columnKey: string; value: string }>) => void;
 }
 
 const toColumnLabel = (index: number): string => {
@@ -31,7 +34,7 @@ type CellPosition = {
   columnKey: string;
 };
 
-const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
+const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell, onCommitCells }) => {
   const columnLabels = useMemo(() => {
     if (!sheet) return [];
     const count = Math.min(sheet.gridSize.cols, 26);
@@ -50,6 +53,7 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
   }, [sheet]);
 
   const [selectedCell, setSelectedCell] = useState<CellPosition | null>(null);
+  const [selectionRange, setSelectionRange] = useState<{ start: CellPosition; end: CellPosition } | null>(null);
   const [editingCell, setEditingCell] = useState<CellPosition | null>(null);
   const [editingValue, setEditingValue] = useState<string>('');
   const gridRef = useRef<HTMLDivElement>(null);
@@ -58,25 +62,45 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
   useEffect(() => {
     if (!sheet) {
       setSelectedCell(null);
+      setSelectionRange(null);
       setEditingCell(null);
       setEditingValue('');
       return;
     }
 
-    if (selectedCell) {
-      const rowExists = rowNumbers.includes(Number(selectedCell.rowKey));
-      const columnExists = columnLabels.includes(selectedCell.columnKey);
+    const ensureWithinBounds = (cell: CellPosition | null): CellPosition | null => {
+      if (!cell) return null;
+      const rowExists = rowNumbers.includes(Number(cell.rowKey));
+      const columnExists = columnLabels.includes(cell.columnKey);
       if (rowExists && columnExists) {
-        return;
+        return cell;
       }
+      return null;
+    };
+
+    const currentCell = ensureWithinBounds(selectedCell);
+    if (currentCell) {
+      setSelectedCell(currentCell);
+      setSelectionRange((prev) => {
+        if (!prev) {
+          return { start: currentCell, end: currentCell };
+        }
+        const start = ensureWithinBounds(prev.start) ?? currentCell;
+        const end = ensureWithinBounds(prev.end) ?? currentCell;
+        return { start, end };
+      });
+      return;
     }
 
     const firstRow = rowNumbers[0];
     const firstColumn = columnLabels[0];
     if (firstRow !== undefined && firstColumn) {
-      setSelectedCell({ rowKey: String(firstRow), columnKey: firstColumn });
+      const cell = { rowKey: String(firstRow), columnKey: firstColumn };
+      setSelectedCell(cell);
+      setSelectionRange({ start: cell, end: cell });
     } else {
       setSelectedCell(null);
+      setSelectionRange(null);
     }
     setEditingCell(null);
     setEditingValue('');
@@ -121,7 +145,7 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
   }, [sheet, editingCell, editingValue, onCommitCell]);
 
   const moveSelection = useCallback(
-    (deltaRow: number, deltaCol: number) => {
+    (deltaRow: number, deltaCol: number, extend = false) => {
       if (!selectedCell || !sheet) return;
       const rowIndex = rowNumbers.findIndex((num) => String(num) === selectedCell.rowKey);
       const colIndex = columnLabels.findIndex((label) => label === selectedCell.columnKey);
@@ -133,7 +157,15 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
       const nextRow = rowNumbers[nextRowIndex];
       const nextCol = columnLabels[nextColIndex];
       if (nextRow !== undefined && nextCol) {
-        setSelectedCell({ rowKey: String(nextRow), columnKey: nextCol });
+        const nextCell = { rowKey: String(nextRow), columnKey: nextCol };
+        setSelectedCell(nextCell);
+        setSelectionRange((prev) => {
+          if (!extend) {
+            return { start: nextCell, end: nextCell };
+          }
+          const anchor = prev?.start ?? selectedCell ?? nextCell;
+          return { start: anchor, end: nextCell };
+        });
         setEditingCell(null);
       }
     },
@@ -143,6 +175,116 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
   const isPrintableKey = (event: KeyboardEvent<HTMLElement>): boolean => {
     return event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey;
   };
+
+  const updateSelection = useCallback((cell: CellPosition) => {
+    setSelectedCell(cell);
+    setSelectionRange({ start: cell, end: cell });
+  }, []);
+
+  const handleCellMouseDown = useCallback(
+    (event: MouseEvent<HTMLTableCellElement>, rowKey: string, columnKey: string) => {
+      event.preventDefault();
+      const cell = { rowKey, columnKey };
+      setEditingCell(null);
+      if (event.shiftKey && (selectionRange || selectedCell)) {
+        const anchor = selectionRange?.start ?? selectedCell ?? cell;
+        setSelectedCell(cell);
+        setSelectionRange({ start: anchor, end: cell });
+      } else {
+        updateSelection(cell);
+      }
+    },
+    [selectionRange, updateSelection, selectedCell]
+  );
+
+  const handleDoubleClick = useCallback(
+    (rowKey: string, columnKey: string) => {
+      const cell = { rowKey, columnKey };
+      updateSelection(cell);
+      startEditing();
+    },
+    [startEditing, updateSelection]
+  );
+
+  if (!sheet) {
+    return <div className="sheet-grid__empty">シートを選択してください。</div>;
+  }
+
+  const getCellDisplayValue = (rowKey: string, columnKey: string): string => {
+    const rowData = sheet.rows[rowKey] ?? {};
+    const cell = rowData[columnKey];
+    if (cell === undefined || cell.value === null) return '';
+    return String(cell.value);
+  };
+
+  const getCellPosition = (rowKey: string, columnKey: string): { rowIndex: number; colIndex: number } | null => {
+    const rowIndex = rowNumbers.findIndex((num) => String(num) === rowKey);
+    const colIndex = columnLabels.findIndex((label) => label === columnKey);
+    if (rowIndex === -1 || colIndex === -1) return null;
+    return { rowIndex, colIndex };
+  };
+
+  const isSelected = (rowKey: string, columnKey: string): boolean =>
+    selectedCell?.rowKey === rowKey && selectedCell?.columnKey === columnKey;
+
+  const isInSelectionRange = (rowKey: string, columnKey: string): boolean => {
+    if (!selectionRange) return false;
+    const startPos = getCellPosition(selectionRange.start.rowKey, selectionRange.start.columnKey);
+    const endPos = getCellPosition(selectionRange.end.rowKey, selectionRange.end.columnKey);
+    const cellPos = getCellPosition(rowKey, columnKey);
+    if (!startPos || !endPos || !cellPos) return false;
+    const rowMin = Math.min(startPos.rowIndex, endPos.rowIndex);
+    const rowMax = Math.max(startPos.rowIndex, endPos.rowIndex);
+    const colMin = Math.min(startPos.colIndex, endPos.colIndex);
+    const colMax = Math.max(startPos.colIndex, endPos.colIndex);
+    return cellPos.rowIndex >= rowMin && cellPos.rowIndex <= rowMax && cellPos.colIndex >= colMin && cellPos.colIndex <= colMax;
+  };
+
+  const copySelection = useCallback(async () => {
+    if (!sheet || !selectionRange) return;
+    const startPos = getCellPosition(selectionRange.start.rowKey, selectionRange.start.columnKey);
+    const endPos = getCellPosition(selectionRange.end.rowKey, selectionRange.end.columnKey);
+    if (!startPos || !endPos) return;
+
+    const rowMin = Math.min(startPos.rowIndex, endPos.rowIndex);
+    const rowMax = Math.max(startPos.rowIndex, endPos.rowIndex);
+    const colMin = Math.min(startPos.colIndex, endPos.colIndex);
+    const colMax = Math.max(startPos.colIndex, endPos.colIndex);
+
+    const lines: string[] = [];
+    for (let r = rowMin; r <= rowMax; r += 1) {
+      const rowKey = String(rowNumbers[r]);
+      const rowValues: string[] = [];
+      for (let c = colMin; c <= colMax; c += 1) {
+        const columnKey = columnLabels[c];
+        rowValues.push(getCellDisplayValue(rowKey, columnKey));
+      }
+      lines.push(rowValues.join('\t'));
+    }
+    const text = lines.join('\n');
+
+    const fallbackCopy = (content: string) => {
+      const textarea = document.createElement('textarea');
+      textarea.value = content;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'absolute';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    };
+
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        fallbackCopy(text);
+      }
+    } catch (error) {
+      fallbackCopy(text);
+    }
+  }, [sheet, selectionRange, rowNumbers, columnLabels, getCellDisplayValue, getCellPosition]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
@@ -163,19 +305,19 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
       switch (event.key) {
         case 'ArrowUp':
           event.preventDefault();
-          moveSelection(-1, 0);
+          moveSelection(-1, 0, event.shiftKey);
           break;
         case 'ArrowDown':
           event.preventDefault();
-          moveSelection(1, 0);
+          moveSelection(1, 0, event.shiftKey);
           break;
         case 'ArrowLeft':
           event.preventDefault();
-          moveSelection(0, -1);
+          moveSelection(0, -1, event.shiftKey);
           break;
         case 'ArrowRight':
           event.preventDefault();
-          moveSelection(0, 1);
+          moveSelection(0, 1, event.shiftKey);
           break;
         case 'Enter':
           event.preventDefault();
@@ -183,13 +325,26 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
           break;
         case 'Tab':
           event.preventDefault();
-          moveSelection(0, event.shiftKey ? -1 : 1);
+          moveSelection(0, event.shiftKey ? -1 : 1, event.shiftKey);
           break;
         case 'Backspace':
         case 'Delete':
           if (selectedCell && onCommitCell) {
             event.preventDefault();
             void onCommitCell(selectedCell.rowKey, selectedCell.columnKey, '');
+          }
+          break;
+        case 'c':
+        case 'C':
+          if ((event.metaKey || event.ctrlKey) && selectionRange) {
+            event.preventDefault();
+            void copySelection();
+          }
+          break;
+        case 'v':
+        case 'V':
+          if ((event.metaKey || event.ctrlKey) && !editingCell) {
+            // Allow onPaste handler to handle actual paste
           }
           break;
         default:
@@ -200,35 +355,63 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
           break;
       }
     },
-    [sheet, editingCell, commitEditing, cancelEditing, moveSelection, startEditing, selectedCell, onCommitCell]
+    [
+      sheet,
+      editingCell,
+      commitEditing,
+      cancelEditing,
+      moveSelection,
+      startEditing,
+      selectedCell,
+      onCommitCell,
+      selectionRange,
+      copySelection
+    ]
   );
 
-  const handleCellClick = useCallback((rowKey: string, columnKey: string) => {
-    setSelectedCell({ rowKey, columnKey });
-    setEditingCell(null);
-  }, []);
+  const handlePaste = useCallback(
+    (event: ClipboardEvent<HTMLDivElement>) => {
+      if (!sheet || editingCell || !selectedCell || !onCommitCells) return;
+      const clipboardText = event.clipboardData.getData('text/plain');
+      if (!clipboardText) return;
 
-  const handleDoubleClick = useCallback(
-    (rowKey: string, columnKey: string) => {
-      setSelectedCell({ rowKey, columnKey });
-      startEditing();
+      event.preventDefault();
+
+      const startPos = getCellPosition(selectedCell.rowKey, selectedCell.columnKey);
+      if (!startPos) return;
+
+      const rows = clipboardText
+        .replace(/\r/g, '')
+        .split('\n')
+        .filter((line) => line.length > 0);
+
+      if (rows.length === 0) return;
+
+      const updates: Array<{ rowKey: string; columnKey: string; value: string }> = [];
+      let lastCell: CellPosition = selectedCell;
+
+      rows.forEach((line, rowOffset) => {
+        const columns = line.split('\t');
+        columns.forEach((value, colOffset) => {
+          const targetRowIndex = startPos.rowIndex + rowOffset;
+          const targetColIndex = startPos.colIndex + colOffset;
+          if (targetRowIndex >= rowNumbers.length || targetColIndex >= columnLabels.length) {
+            return;
+          }
+          const rowKey = String(rowNumbers[targetRowIndex]);
+          const columnKey = columnLabels[targetColIndex];
+          updates.push({ rowKey, columnKey, value });
+          lastCell = { rowKey, columnKey };
+        });
+      });
+
+      if (updates.length === 0) return;
+      onCommitCells(updates);
+      setSelectedCell(lastCell);
+      setSelectionRange({ start: selectedCell, end: lastCell });
     },
-    [startEditing]
+    [sheet, editingCell, selectedCell, onCommitCells, rowNumbers, columnLabels, getCellPosition]
   );
-
-  if (!sheet) {
-    return <div className="sheet-grid__empty">シートを選択してください。</div>;
-  }
-
-  const getCellDisplayValue = (rowKey: string, columnKey: string): string => {
-    const rowData = sheet.rows[rowKey] ?? {};
-    const cell = rowData[columnKey];
-    if (cell === undefined || cell.value === null) return '';
-    return String(cell.value);
-  };
-
-  const isSelected = (rowKey: string, columnKey: string): boolean =>
-    selectedCell?.rowKey === rowKey && selectedCell?.columnKey === columnKey;
 
   const isEditing = (rowKey: string, columnKey: string): boolean =>
     editingCell?.rowKey === rowKey && editingCell?.columnKey === columnKey;
@@ -240,6 +423,7 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
       role="grid"
       ref={gridRef}
       onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
     >
       <table className="sheet-grid__table">
         <thead>
@@ -276,11 +460,11 @@ const SheetGrid: FC<SheetGridProps> = ({ sheet, onCommitCell }) => {
                   return (
                     <td
                       key={label}
-                      className={`sheet-grid__cell${selected ? ' sheet-grid__cell--selected' : ''}${
-                        editing ? ' sheet-grid__cell--editing' : ''
-                      }`}
+                      className={`sheet-grid__cell${
+                        selected ? ' sheet-grid__cell--selected' : isInSelectionRange(rowKey, label) ? ' sheet-grid__cell--inRange' : ''
+                      }${editing ? ' sheet-grid__cell--editing' : ''}`}
                       title={title}
-                      onMouseDown={() => handleCellClick(rowKey, label)}
+                      onMouseDown={(event) => handleCellMouseDown(event, rowKey, label)}
                       onDoubleClick={() => handleDoubleClick(rowKey, label)}
                     >
                       {editing ? (


### PR DESCRIPTION
## 背景／目的
- Issue #18 に沿って、キーボード操作を中心としたセル範囲選択とコピー＆ペーストを実装する。
- グリッド上で複数セルをまとめて編集／貼り付けできるようにし、初回リリースの操作体験を強化する。

## 主要な変更点
- `SheetGrid` に範囲選択状態・コピー（Cmd/Ctrl+C）・貼り付け（Cmd/Ctrl+V）処理を追加、Shift+矢印で選択を拡張できるようにした。
- ペースト処理で複数セルを更新できるよう `onCommitCells` ハンドラを App 側に追加。
- 選択範囲のハイライトを視認しやすくするため CSS を調整し、偶数行でも青系の背景になるようにした。

## 動作確認
- `bun run build`
- ブラウザ（`bun run dev`）で以下を確認
  - Shift+矢印キーで範囲選択し Cmd/Ctrl+C → 他のセルに Cmd/Ctrl+V で貼り付け可能
  - 複数セルをコピーした状態で貼り付けると対応範囲のセルが更新される
  - 単一セルの直接編集は従来どおり動作する

Closes #18