### PR TITLE
fix: 新規ブック作成時にファイル名を入力名に揃える

### DIFF
--- a/src/lib/workspace/bookFactory.ts
+++ b/src/lib/workspace/bookFactory.ts
@@ -8,6 +8,9 @@ const DEFAULT_COLS = 26;
 
 const normalizeName = (name: string): string => name.trim();
 
+const buildBookFileName = (bookName: string): string =>
+  `${bookName.replace(/\//g, '／')}.json`;
+
 const hasBackslash = (path: string): boolean => path.includes('\\');
 
 const normalizeSeparators = (value: string): string => value.replace(/\\/g, '/');
@@ -61,7 +64,8 @@ export const buildNewBookSnapshot = (
   const sheetId = generateId('sheet');
 
   const workspaceDir = resolveWorkspaceDir(snapshot.workspace.filePath);
-  const dataPath = `${BOOKS_DIR}/${bookId}.json`;
+  const fileName = buildBookFileName(trimmedName);
+  const dataPath = `${BOOKS_DIR}/${fileName}`;
   const absoluteBookPath = joinWorkspacePath(workspaceDir, dataPath);
 
   const bookFile: BookFile = {
@@ -91,7 +95,7 @@ export const buildNewBookSnapshot = (
 
   const bookReference: BookReference = {
     id: bookId,
-    name: `${bookId}.json`,
+    name: buildBookFileName(trimmedName),
     folderId: null,
     order: nextOrder,
     dataPath,


### PR DESCRIPTION
## 背景 / 目的
- Issue #42 で報告された通り、新しいブックを作成すると `books/{bookId}.json` のようなファイル名が割り当てられ、ユーザーが入力した名前と一致しない状態だった。
- ブックの参照名（ファイル名）も入力値に基づかせることで、ファイルシステムとの整合が取れるようにする。

## 変更点
- `buildNewBookSnapshot` でファイル名を生成するとき、ブックIDではなくユーザーが入力した名前（トリム済み）を `.json` 付きで利用するよう変更。
- `/` をファイル名に含めないよう全角スラッシュに置き換える簡易サニタイズを追加。

## 動作確認
- `bun x tsc --noEmit`
- 「売上レポート」など任意の名前でブックを作成し、`books/売上レポート.json` が生成されることを確認。