### PR TITLE
feat: グリッド下部にシートタブを配置

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -283,6 +283,128 @@ button {
   min-height: 0;
   padding: 0 28px 28px;
   display: flex;
+  overflow-x: hidden;
+  box-sizing: border-box;
+}
+
+.main-view__workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.main-view__gridContainer {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.main-view__gridContainer .sheet-grid {
+  flex: 1;
+}
+
+.sheet-tabs {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.1);
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.sheet-tabs__scrollArea {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+  scroll-behavior: smooth;
+}
+
+.sheet-tabs__scrollArea::-webkit-scrollbar {
+  height: 6px;
+}
+
+.sheet-tabs__scrollArea::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.5);
+  border-radius: 999px;
+}
+
+.sheet-tabs__list {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sheet-tabs__tab {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 16px;
+  background: #e5e7eb;
+  color: #374151;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.sheet-tabs__tab:hover {
+  background: #d1d5db;
+}
+
+.sheet-tabs__tab--active {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+}
+
+.sheet-tabs__placeholder {
+  color: #6b7280;
+  font-size: 0.85rem;
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.sheet-tabs__addButton {
+  border: none;
+  border-radius: 10px;
+  padding: 8px 14px;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  flex-shrink: 0;
+}
+
+.sheet-tabs__addButton:disabled {
+  background: #d1d5db;
+  color: #6b7280;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.sheet-tabs__addButton:not(:disabled):hover {
+  background: #1d4ed8;
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
+}
+
+.sheet-tabs--empty {
+  justify-content: center;
+  color: #6b7280;
+  font-size: 0.9rem;
 }
 
 .main-view__empty {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import Sidebar from './components/Sidebar';
 import SheetGrid from './components/SheetGrid';
+import Sidebar from './components/Sidebar';
+import SheetTabs from './components/SheetTabs';
 import { isTauri } from './lib/env';
 import {
   openWorkspaceFromDialog,
@@ -246,11 +247,8 @@ function App() {
         workspace={workspaceFile}
         books={bookFiles}
         selectedBookId={selectedBookId}
-        selectedSheetId={selectedSheetId}
         onSelectBook={handleSelectBook}
-        onSelectSheet={handleSelectSheet}
         onCreateBook={handleCreateBook}
-        onCreateSheet={handleCreateSheet}
       />
       <section className="main-view">
         <header className="main-view__header">
@@ -304,11 +302,30 @@ function App() {
         </header>
         <div className="main-view__content">
           {snapshot ? (
-            <SheetGrid
-              sheet={activeSheet ?? null}
-              onCommitCell={handleCommitCell}
-              onCommitCells={handleCommitCells}
-            />
+            <div className="main-view__workspace">
+              <div className="main-view__gridContainer">
+                <SheetGrid
+                  sheet={activeSheet ?? null}
+                  onCommitCell={handleCommitCell}
+                  onCommitCells={handleCommitCells}
+                />
+              </div>
+              <SheetTabs
+                book={activeBook}
+                selectedSheetId={selectedSheetId}
+                onSelectSheet={(sheetId) => {
+                  if (!activeBook) return;
+                  handleSelectSheet(activeBook.book.id, sheetId);
+                }}
+                onCreateSheet={
+                  activeBook
+                    ? () => {
+                        void handleCreateSheet(activeBook.book.id);
+                      }
+                    : undefined
+                }
+              />
+            </div>
           ) : (
             renderEmptyState()
           )}

--- a/src/components/SheetTabs.tsx
+++ b/src/components/SheetTabs.tsx
@@ -1,0 +1,67 @@
+import { type FC } from 'react';
+import type { BookFile } from '../types/schema';
+
+interface SheetTabsProps {
+  book: BookFile | null;
+  selectedSheetId?: string | null;
+  onSelectSheet: (sheetId: string) => void;
+  onCreateSheet?: () => void;
+}
+
+const SheetTabs: FC<SheetTabsProps> = ({ book, selectedSheetId, onSelectSheet, onCreateSheet }) => {
+  if (!book) {
+    return (
+      <div className="sheet-tabs sheet-tabs--empty">
+        <span>ブックを選択するとシートの一覧が表示されます。</span>
+      </div>
+    );
+  }
+
+  const handleSelect = (sheetId: string) => {
+    if (sheetId === selectedSheetId) {
+      return;
+    }
+    onSelectSheet(sheetId);
+  };
+
+  const handleCreate = () => {
+    onCreateSheet?.();
+  };
+
+  return (
+    <div className="sheet-tabs">
+      <div className="sheet-tabs__scrollArea">
+        <div className="sheet-tabs__list" role="tablist" aria-label="シート">
+          {book.sheets.map((sheet) => {
+            const isActive = sheet.id === selectedSheetId;
+            return (
+              <button
+                key={sheet.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`sheet-tabs__tab${isActive ? ' sheet-tabs__tab--active' : ''}`}
+                onClick={() => handleSelect(sheet.id)}
+              >
+                {sheet.name}
+              </button>
+            );
+          })}
+          {book.sheets.length === 0 && (
+            <span className="sheet-tabs__placeholder">シートがありません</span>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="sheet-tabs__addButton"
+        onClick={handleCreate}
+        disabled={!onCreateSheet}
+      >
+        + シート追加
+      </button>
+    </div>
+  );
+};
+
+export default SheetTabs;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,37 +1,23 @@
-import { useMemo, type FC } from 'react';
+import { type FC } from 'react';
 import type { WorkspaceFile, BookFile } from '../types/schema';
 
 interface SidebarProps {
   workspace: WorkspaceFile | null;
   books: BookFile[];
   selectedBookId?: string | null;
-  selectedSheetId?: string | null;
   onSelectBook: (bookId: string) => void;
-  onSelectSheet: (bookId: string, sheetId: string) => void;
   onCreateBook?: () => void;
-  onCreateSheet?: (bookId: string) => void;
 }
 
 const trimExtension = (name: string): string => name.replace(/\.json$/i, '');
 
-const Sidebar: FC<SidebarProps> = ({
-  workspace,
-  books,
-  selectedBookId,
-  selectedSheetId,
-  onSelectBook,
-  onSelectSheet,
-  onCreateBook,
-  onCreateSheet
-}) => {
-  const booksById = useMemo(() => new Map(books.map((book) => [book.book.id, book])), [books]);
+const Sidebar: FC<SidebarProps> = ({ workspace, books, selectedBookId, onSelectBook, onCreateBook }) => {
   const workspaceMeta = workspace?.workspace;
   const workspaceBooks = workspace?.books ?? [];
   const createBookDisabled = !workspace || !onCreateBook;
   const createBookTitle = createBookDisabled
     ? 'ワークスペースを開いてから新規ブックを作成できます'
     : '新しいブックを追加';
-  const createSheetDisabled = !onCreateSheet;
 
   return (
     <aside className="sidebar">
@@ -42,7 +28,7 @@ const Sidebar: FC<SidebarProps> = ({
       <nav className="sidebar__body">
         <ul className="sidebar__bookList">
           {workspaceBooks.map((bookRef) => {
-            const book = booksById.get(bookRef.id);
+            const book = books.find((entry) => entry.book.id === bookRef.id);
             const isActive = bookRef.id === selectedBookId;
             const displayName = book?.book.name ?? trimExtension(bookRef.name);
 
@@ -58,38 +44,6 @@ const Sidebar: FC<SidebarProps> = ({
                   </span>
                   <span>{displayName}</span>
                 </button>
-                {isActive && book ? (
-                  <ul className="sidebar__sheetList">
-                    {book.sheets.map((sheet) => {
-                      const sheetActive = sheet.id === selectedSheetId;
-                      return (
-                        <li key={sheet.id}>
-                          <button
-                            type="button"
-                            className={`sidebar__sheetButton${sheetActive ? ' sidebar__sheetButton--active' : ''}`}
-                            onClick={() => onSelectSheet(bookRef.id, sheet.id)}
-                          >
-                            {sheet.name}
-                          </button>
-                        </li>
-                      );
-                    })}
-                    {book.sheets.length === 0 && (
-                      <li className="sidebar__empty">シートがありません</li>
-                    )}
-                    <li>
-                      <button
-                        type="button"
-                        className="sidebar__sheetAddButton"
-                        disabled={createSheetDisabled}
-                        onClick={() => onCreateSheet?.(bookRef.id)}
-                        title="このブックに新しいシートを追加"
-                      >
-                        + 新しいシート
-                      </button>
-                    </li>
-                  </ul>
-                ) : null}
               </li>
             );
           })}


### PR DESCRIPTION
## 背景 / 目的
- Issue #45 に従い、シートの切り替え UI をグリッド下部に配置し、スプレッドシート風の操作性に揃える。
- Sidebar にあったシート一覧を移設し、切り替え・追加の動線をグリッド直下で完結させる。

## 変更点
- Sidebar からシート一覧・追加ボタンを排除し、ブック選択専用に整理。
- 新規コンポーネント `SheetTabs` を追加し、シートタブと「+ シート追加」ボタンをグリッド下部に表示。
- 横スクロールはタブ部分のみで動き、追加ボタンは常時表示されるようスタイルを調整。
- `App.tsx` / `App.css` を更新し、新レイアウトに合わせた構造とスタイルを実装。

## 動作確認
- `bun x tsc --noEmit`
- ブックを複数シート持たせる → タブで切替できることを確認。
- シートタブが画面幅を超える場合でも横スクロールでタブ操作ができ、右端の「+ シート追加」ボタンが常に押下可能な位置にあることを手動確認。
