### PR TITLE
feat: ブック名をヘッダーでインライン編集可能に

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -210,6 +210,45 @@ button {
   margin: 6px 0 0;
   font-size: 0.9rem;
   color: #6b7280;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.main-view__bookNameButton {
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.main-view__bookNameButton:hover,
+.main-view__bookNameButton:focus {
+  border-color: #94a3b8;
+  background: rgba(148, 163, 184, 0.15);
+  outline: none;
+}
+
+.main-view__bookNameInput {
+  font: inherit;
+  color: #111827;
+  border: 1px solid #94a3b8;
+  border-radius: 6px;
+  padding: 6px 10px;
+  min-width: 200px;
+  max-width: min(100%, 360px);
+  box-sizing: border-box;
+  background: #ffffff;
+}
+
+.main-view__bookNameInput:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 
 .main-view__meta {


### PR DESCRIPTION
## 背景 / 目的
- Issue #10 対応。ブック名を window.prompt で変更していたが、ヘッダー上で直接編集できるよう改善。

## 変更点
- `App.tsx`: アクティブブック名をクリックで編集モードに切り替えるインライン編集ロジックを追加。
- `App.css`: 編集用入力欄とボタンのスタイルを追加。
- `workspaceStore`: `renameBook` アクションを利用し、Undo 履歴を残しつつ名前変更・タイムスタンプ更新を実施。

## 動作確認
- `bun x tsc --noEmit`
- ブック名をクリック → 入力欄表示 → Enter / 別クリックで確定。
- Esc キーでキャンセルされ、元の名前に戻ることを確認。
- 自動保存無効時に名前変更 → `保存` ボタンで保存可能なことを確認。
