### PR TITLE
chore: ヘッダーのブック・シート表示順を調整

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -346,10 +346,6 @@ function App() {
         <header className="main-view__header">
           <div>
             <h2 className="main-view__title">
-              {activeSheet?.name ??
-                (snapshot ? 'シートを選択してください' : 'ワークスペースを開いてください')}
-            </h2>
-            <div className="main-view__subtitle">
               {activeBook ? (
                 isRenaming ? (
                   <input
@@ -382,6 +378,13 @@ function App() {
               ) : (
                 'データはまだ読み込まれていません'
               )}
+            </h2>
+            <div className="main-view__subtitle">
+              {activeSheet
+                ? activeSheet.name
+                : snapshot
+                  ? 'シートを選択してください'
+                  : 'ワークスペースを開いてください'}
             </div>
           </div>
           <div className="main-view__headerActions">


### PR DESCRIPTION
## 背景 / 目的
- Issue #10 の対応後、ヘッダーでブック名とシート名を表示する順序が逆転していた。
- ブック名がより上位の情報として扱われるよう、表示順を『ブック → シート』に統一する。

## 変更点
- `App.tsx` のヘッダー構造を入れ替え、見出し (h2) にブック名、サブタイトルにシート名を表示。
- インライン編集ロジックはそのまま活かしつつ、文言の fallback も新しい順序に合わせて調整。

## 動作確認
- `bun x tsc --noEmit`
- ブック名のインライン編集が継続して機能すること、およびシート名がサブタイトルに表示されることを手動確認。