### PR TITLE
feat: ブック削除機能に確認ダイアログを導入

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod workspace;
 
-use workspace::{load_workspace_snapshot, save_workspace_snapshot};
+use workspace::{delete_book_file, load_workspace_snapshot, save_workspace_snapshot};
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
@@ -16,7 +16,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             greet,
             load_workspace_snapshot,
-            save_workspace_snapshot
+            save_workspace_snapshot,
+            delete_book_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -101,3 +101,18 @@ pub fn save_workspace_snapshot(snapshot: WorkspaceSnapshotPayload) -> Result<(),
 
     Ok(())
 }
+
+#[tauri::command]
+pub fn delete_book_file(path: String) -> Result<(), String> {
+    let path = PathBuf::from(path);
+    match fs::remove_file(&path) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                Ok(())
+            } else {
+                Err(format!("Failed to delete {}: {}", path.display(), err))
+            }
+        }
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -91,6 +91,33 @@ button {
   background: rgba(255, 255, 255, 0.12);
 }
 
+.sidebar__bookRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sidebar__bookDeleteButton {
+  border: none;
+  border-radius: 6px;
+  padding: 4px 8px;
+  background: rgba(239, 68, 68, 0.2);
+  color: rgba(254, 226, 226, 0.95);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__bookDeleteButton:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.35);
+  color: #fee2e2;
+}
+
+.sidebar__bookDeleteButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .sidebar__bookEmoji {
   font-size: 0.9rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,8 @@ import { isTauri } from './lib/env';
 import {
   openWorkspaceFromDialog,
   saveWorkspaceSnapshot,
-  showErrorDialog
+  showErrorDialog,
+  deleteBookFile
 } from './lib/tauri/workspaceBridge';
 import type { BookFile } from './types/schema';
 import { useWorkspaceStore, type CellUpdate } from './state/workspaceStore';
@@ -31,6 +32,7 @@ function App() {
   const createSheet = useWorkspaceStore((state) => state.createSheet);
   const applyCellUpdates = useWorkspaceStore((state) => state.applyCellUpdates);
   const renameBook = useWorkspaceStore((state) => state.renameBook);
+  const deleteBook = useWorkspaceStore((state) => state.deleteBook);
   const undo = useWorkspaceStore((state) => state.undo);
   const redo = useWorkspaceStore((state) => state.redo);
 
@@ -281,6 +283,49 @@ function App() {
     void finishRename();
   }, [finishRename]);
 
+  const handleDeleteBook = useCallback(
+    async (bookId: string) => {
+      const currentSnapshot = useWorkspaceStore.getState().snapshot;
+      const bookEntry = currentSnapshot?.books.find((entry) => entry.data.book.id === bookId);
+      if (!bookEntry) {
+        return;
+      }
+
+      const bookName = bookEntry.data.book.name ?? '名称未設定のブック';
+      const confirmed = await Promise.resolve(
+        window.confirm(`「${bookName}」を削除しますか？この操作は元に戻せません。`)
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      const nextSnapshot = deleteBook(bookId);
+      if (!nextSnapshot) {
+        return;
+      }
+
+      if (isTauri) {
+        try {
+          await deleteBookFile(bookEntry.filePath);
+        } catch (error) {
+          await showErrorDialog('ブックファイルの削除に失敗しました', toErrorMessage(error));
+        }
+      }
+
+      if (isTauri && !autoSaveEnabled) {
+        setBusyState('saving');
+        try {
+          await saveWorkspaceSnapshot(nextSnapshot);
+        } catch (error) {
+          await showErrorDialog('ブック削除後の保存に失敗しました', toErrorMessage(error));
+        } finally {
+          setBusyState('idle');
+        }
+      }
+    },
+    [autoSaveEnabled, deleteBook, setBusyState]
+  );
+
   const handleUndo = useCallback(() => {
     undo();
   }, [undo]);
@@ -341,6 +386,7 @@ function App() {
         selectedBookId={selectedBookId}
         onSelectBook={handleSelectBook}
         onCreateBook={handleCreateBook}
+        onDeleteBook={handleDeleteBook}
       />
       <section className="main-view">
         <header className="main-view__header">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,17 +7,26 @@ interface SidebarProps {
   selectedBookId?: string | null;
   onSelectBook: (bookId: string) => void;
   onCreateBook?: () => void;
+  onDeleteBook?: (bookId: string) => void;
 }
 
 const trimExtension = (name: string): string => name.replace(/\.json$/i, '');
 
-const Sidebar: FC<SidebarProps> = ({ workspace, books, selectedBookId, onSelectBook, onCreateBook }) => {
+const Sidebar: FC<SidebarProps> = ({
+  workspace,
+  books,
+  selectedBookId,
+  onSelectBook,
+  onCreateBook,
+  onDeleteBook
+}) => {
   const workspaceMeta = workspace?.workspace;
   const workspaceBooks = workspace?.books ?? [];
   const createBookDisabled = !workspace || !onCreateBook;
   const createBookTitle = createBookDisabled
     ? 'ワークスペースを開いてから新規ブックを作成できます'
     : '新しいブックを追加';
+  const deleteBookDisabled = !onDeleteBook;
 
   return (
     <aside className="sidebar">
@@ -34,16 +43,27 @@ const Sidebar: FC<SidebarProps> = ({ workspace, books, selectedBookId, onSelectB
 
             return (
               <li key={bookRef.id} className="sidebar__bookItem">
-                <button
-                  type="button"
-                  className={`sidebar__bookButton${isActive ? ' sidebar__bookButton--active' : ''}`}
-                  onClick={() => onSelectBook(bookRef.id)}
-                >
-                  <span className="sidebar__bookEmoji" role="img" aria-hidden="true">
-                    📄
-                  </span>
-                  <span>{displayName}</span>
-                </button>
+                <div className="sidebar__bookRow">
+                  <button
+                    type="button"
+                    className={`sidebar__bookButton${isActive ? ' sidebar__bookButton--active' : ''}`}
+                    onClick={() => onSelectBook(bookRef.id)}
+                  >
+                    <span className="sidebar__bookEmoji" role="img" aria-hidden="true">
+                      📄
+                    </span>
+                    <span>{displayName}</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="sidebar__bookDeleteButton"
+                    onClick={() => onDeleteBook?.(bookRef.id)}
+                    disabled={deleteBookDisabled}
+                    title="このブックを削除"
+                  >
+                    削除
+                  </button>
+                </div>
               </li>
             );
           })}

--- a/src/lib/tauri/workspaceBridge.ts
+++ b/src/lib/tauri/workspaceBridge.ts
@@ -86,6 +86,10 @@ export const saveWorkspaceSnapshot = async (
   await invoke('save_workspace_snapshot', { snapshot });
 };
 
+export const deleteBookFile = async (path: string): Promise<void> => {
+  await invoke('delete_book_file', { path });
+};
+
 export const openWorkspaceFromDialog = async (): Promise<WorkspaceSnapshot | null> => {
   const directory = await selectWorkspaceDirectory();
   if (!directory) {


### PR DESCRIPTION
## 背景
- #56 を #57 にてRevertしたため、再度マージ

## 変更内容
- Sidebar に削除ボタンを追加し、ブックごとに確認ダイアログを表示するロジックを実装
- `state/workspaceStore` に `deleteBook` アクションを追加し、スナップショット・最近リスト・選択状態を更新
- Tauri 側に `delete_book_file` コマンドを追加し、削除確定後に JSON ファイルを物理削除
- 確認後のみ `saveWorkspaceSnapshot` を呼び出し、自動保存オフ時でも一貫した挙動に

## 動作確認
- `bun run build`
