### PR TITLE
feat: シート削除機能を実装

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -428,6 +428,7 @@ button {
   justify-content: center;
   min-height: 32px;
   outline: none;
+  gap: 8px;
 }
 
 .sheet-tabs__tab--active {
@@ -461,6 +462,32 @@ button {
 
 .sheet-tabs__renameInput::placeholder {
   color: rgba(55, 65, 81, 0.6);
+}
+
+.sheet-tabs__deleteButton {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 6px;
+  line-height: 1;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sheet-tabs__deleteButton:hover {
+  background: rgba(15, 23, 42, 0.08);
+  color: #ef4444;
+}
+
+.sheet-tabs__tab--active .sheet-tabs__deleteButton {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.sheet-tabs__tab--active .sheet-tabs__deleteButton:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fee2e2;
 }
 
 .sheet-tabs__placeholder {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ function App() {
   const applyCellUpdates = useWorkspaceStore((state) => state.applyCellUpdates);
   const renameBook = useWorkspaceStore((state) => state.renameBook);
   const renameSheet = useWorkspaceStore((state) => state.renameSheet);
+  const deleteSheet = useWorkspaceStore((state) => state.deleteSheet);
   const deleteBook = useWorkspaceStore((state) => state.deleteBook);
   const undo = useWorkspaceStore((state) => state.undo);
   const redo = useWorkspaceStore((state) => state.redo);
@@ -402,6 +403,48 @@ function App() {
     void finishSheetRename();
   }, [finishSheetRename]);
 
+  const handleDeleteSheet = useCallback(
+    async (bookId: string, sheetId: string) => {
+      const currentSnapshot = useWorkspaceStore.getState().snapshot;
+      const bookEntry = currentSnapshot?.books.find((entry) => entry.data.book.id === bookId);
+      const sheetEntry = bookEntry?.data.sheets.find((entry) => entry.id === sheetId);
+      if (!sheetEntry) {
+        return;
+      }
+
+      const sheetName = sheetEntry.name ?? '名称未設定のシート';
+      const confirmed = await Promise.resolve(
+        window.confirm(`シート「${sheetName}」を削除しますか？この操作は元に戻せません。`)
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      const nextSnapshot = deleteSheet(bookId, sheetId);
+      if (!nextSnapshot) {
+        return;
+      }
+
+      if (renamingSheetId === sheetId) {
+        setRenamingSheetId(null);
+        setDraftSheetName('');
+        skipSheetBlurCommitRef.current = false;
+      }
+
+      if (isTauri && !autoSaveEnabled) {
+        setBusyState('saving');
+        try {
+          await saveWorkspaceSnapshot(nextSnapshot);
+        } catch (error) {
+          await showErrorDialog('シート削除後の保存に失敗しました', toErrorMessage(error));
+        } finally {
+          setBusyState('idle');
+        }
+      }
+    },
+    [autoSaveEnabled, deleteSheet, renamingSheetId, setBusyState]
+  );
+
   const handleDeleteBook = useCallback(
     async (bookId: string) => {
       const currentSnapshot = useWorkspaceStore.getState().snapshot;
@@ -621,6 +664,18 @@ function App() {
                 onRenameCancel={cancelSheetRename}
                 onRenameBlur={handleSheetRenameBlur}
                 renameInputRef={sheetRenameInputRef}
+                onDeleteSheet={
+                  activeBook
+                    ? (sheetId) => {
+                        void handleDeleteSheet(activeBook.book.id, sheetId);
+                      }
+                    : undefined
+                }
+                canDeleteSheet={
+                  activeBook
+                    ? (_sheetId) => (activeBook.sheets ?? []).length > 1
+                    : undefined
+                }
               />
             </div>
           ) : (

--- a/src/components/SheetTabs.tsx
+++ b/src/components/SheetTabs.tsx
@@ -14,6 +14,8 @@ interface SheetTabsProps {
   onRenameCancel?: () => void;
   onRenameBlur?: () => void;
   renameInputRef?: MutableRefObject<HTMLInputElement | null>;
+  onDeleteSheet?: (sheetId: string) => void;
+  canDeleteSheet?: (sheetId: string) => boolean;
 }
 
 const SheetTabs: FC<SheetTabsProps> = ({
@@ -28,7 +30,9 @@ const SheetTabs: FC<SheetTabsProps> = ({
   onRenameCommit,
   onRenameCancel,
   onRenameBlur,
-  renameInputRef
+  renameInputRef,
+  onDeleteSheet,
+  canDeleteSheet
 }) => {
   if (!book) {
     return (
@@ -56,6 +60,8 @@ const SheetTabs: FC<SheetTabsProps> = ({
           {book.sheets.map((sheet) => {
             const isActive = sheet.id === selectedSheetId;
             const isRenaming = sheet.id === renamingSheetId;
+            const allowDelete =
+              !!onDeleteSheet && (!canDeleteSheet || canDeleteSheet(sheet.id));
             const className = [
               'sheet-tabs__tab',
               isActive ? 'sheet-tabs__tab--active' : '',
@@ -83,6 +89,9 @@ const SheetTabs: FC<SheetTabsProps> = ({
                   } else if (event.key === 'F2') {
                     event.preventDefault();
                     onStartRename?.(sheet.id);
+                  } else if ((event.key === 'Delete' || event.key === 'Backspace') && allowDelete) {
+                    event.preventDefault();
+                    onDeleteSheet?.(sheet.id);
                   }
                 }}
                 onDoubleClick={() => {
@@ -108,7 +117,22 @@ const SheetTabs: FC<SheetTabsProps> = ({
                     }}
                   />
                 ) : (
-                  <span className="sheet-tabs__tabLabel">{sheet.name}</span>
+                  <>
+                    <span className="sheet-tabs__tabLabel">{sheet.name}</span>
+                    {allowDelete ? (
+                      <button
+                        type="button"
+                        className="sheet-tabs__deleteButton"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDeleteSheet?.(sheet.id);
+                        }}
+                        aria-label={`${sheet.name ?? 'シート'}を削除`}
+                      >
+                        ×
+                      </button>
+                    ) : null}
+                  </>
                 )}
               </div>
             );


### PR DESCRIPTION
## 背景／目的
Issue #15 の要件に基づき、シートをタブから削除できるようにしました。

## 主な変更点
- Zustand ストアへ `deleteSheet` アクションを追加し、Undo 履歴・選択状態・recentSheetIds の整合性を確保
- App からシート削除を呼び出すハンドラを実装し、確認ダイアログと Tauri 保存処理を連携
- SheetTabs に削除ボタンと Delete/F2 ショートカットを追加し、リネーム中は削除操作を抑制
- シートタブのスタイルを調整し、削除ボタンのホバー／アクティブ表示を定義

## 動作確認
- `bun x tsc --noEmit`
- シートを削除 → Undo/Redo で復元できることを目視確認

## 残課題
- ブック削除同様に削除後のファイルクリーンアップ（Tauri 側）までは未対応