### PR TITLE
feat: 整合性チェックモーダルと保存ガードを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,6 +91,25 @@ button {
   background: rgba(255, 255, 255, 0.12);
 }
 
+.sidebar__bookButton--broken {
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.sidebar__bookBadge {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(239, 68, 68, 0.9);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
 .sidebar__bookRow {
   display: flex;
   align-items: center;
@@ -321,6 +340,17 @@ button {
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
+.main-view__actionButton--alert {
+  border-color: rgba(239, 68, 68, 0.45);
+  background: rgba(254, 226, 226, 0.4);
+  color: #b91c1c;
+}
+
+.main-view__actionButton--alert:not(:disabled):hover {
+  background: rgba(254, 202, 202, 0.6);
+  box-shadow: 0 4px 14px rgba(239, 68, 68, 0.25);
+}
+
 .main-view__toggle {
   display: flex;
   align-items: center;
@@ -342,6 +372,7 @@ button {
   color: #6b7280;
   display: flex;
   align-items: center;
+  gap: 8px;
 }
 
 .main-view__content {
@@ -573,6 +604,11 @@ button {
   color: #9ca3af;
 }
 
+.main-view__statusAlert {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
 .sheet-grid {
   flex: 1;
   overflow: auto;
@@ -675,6 +711,257 @@ button {
   padding: 40px;
   text-align: center;
   color: #9ca3af;
+}
+
+.integrity-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.integrity-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.integrity-modal__panel {
+  position: relative;
+  z-index: 1001;
+  width: min(720px, 92vw);
+  max-height: 90vh;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.integrity-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 24px;
+  gap: 16px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.integrity-modal__headerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.integrity-modal__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.integrity-modal__subtitle {
+  margin: 8px 0 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.integrity-modal__closeButton {
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+
+.integrity-modal__closeButton:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.integrity-modal__refreshButton {
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #2563eb;
+  font-size: 0.85rem;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.integrity-modal__refreshButton:hover {
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.integrity-modal__content {
+  padding: 0 24px;
+  overflow-y: auto;
+}
+
+.integrity-modal__empty {
+  margin: 32px 0;
+  font-size: 0.95rem;
+  color: #4b5563;
+  text-align: center;
+}
+
+.integrity-modal__issueList {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px 0;
+}
+
+.integrity-modal__issue {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px 18px;
+  background: #f9fafb;
+}
+
+.integrity-modal__issueHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.integrity-modal__severity {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 52px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.integrity-modal__severity--error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.integrity-modal__severity--warning {
+  background: rgba(249, 115, 22, 0.15);
+  color: #c2410c;
+}
+
+.integrity-modal__issueTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #111827;
+  font-weight: 600;
+}
+
+.integrity-modal__options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.integrity-modal__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.integrity-modal__option input {
+  margin-top: 4px;
+}
+
+.integrity-modal__option:hover {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.integrity-modal__option--active {
+  border-color: rgba(59, 130, 246, 0.6);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.integrity-modal__optionLabel {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.integrity-modal__optionDescription {
+  font-size: 0.8rem;
+  color: #4b5563;
+  margin-top: 4px;
+}
+
+.integrity-modal__footer {
+  border-top: 1px solid #e5e7eb;
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: #f9fafb;
+}
+
+.integrity-modal__summary {
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.integrity-modal__footerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.integrity-modal__secondaryButton,
+.integrity-modal__primaryButton {
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.integrity-modal__secondaryButton {
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #1f2937;
+}
+
+.integrity-modal__secondaryButton:hover {
+  background: #f3f4f6;
+}
+
+.integrity-modal__primaryButton {
+  border: none;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.integrity-modal__primaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.integrity-modal__primaryButton:not(:disabled):hover {
+  background: #1d4ed8;
 }
 
 @media (max-width: 960px) {

--- a/src/components/IntegrityModal.tsx
+++ b/src/components/IntegrityModal.tsx
@@ -1,0 +1,189 @@
+import { Fragment, type FC } from 'react';
+import type {
+  IntegrityDecisions,
+  IntegrityDecisionKey,
+  IntegrityIssues
+} from '../types/integrity';
+
+const severityLabel: Record<'error' | 'warning', string> = {
+  error: '重大',
+  warning: '警告'
+};
+
+const decisionOptions: Partial<
+  Record<
+    IntegrityDecisionKey,
+    {
+      label: string;
+      description: string;
+    }
+  >
+> = {
+  useFile: {
+    label: 'ブックファイルに合わせる',
+    description: 'workspace.json の ID やメタ情報をブックファイルの内容に揃えます。'
+  },
+  useWorkspace: {
+    label: 'workspace.json を優先',
+    description: 'ブックファイルの ID やメタ情報を workspace.json の値に書き戻します。'
+  },
+  reset: {
+    label: 'workspace.json を初期化',
+    description: '参照切れの項目をリセットし、安全な初期値に戻します。'
+  },
+  normalize: {
+    label: '並び順を再採番',
+    description: '同じフォルダ内の order を 0 から振り直し、重複や欠損を解消します。'
+  },
+  defer: {
+    label: '後で対応する',
+    description: '今回は修正しません。必要に応じて後で再チェックしてください。'
+  }
+};
+
+const defaultDecisionForIssue = (supported: IntegrityDecisionKey[]): IntegrityDecisionKey =>
+  supported.includes('defer') ? 'defer' : supported[0];
+
+interface IntegrityModalProps {
+  isOpen: boolean;
+  issues: IntegrityIssues;
+  decisions: IntegrityDecisions;
+  onChangeDecision: (issueId: string, decision: IntegrityDecisionKey) => void;
+  onApply: () => void;
+  onClose: () => void;
+  onRefresh?: () => void;
+}
+
+/**
+ * IntegrityModal.
+ * ワークスペースとブックの不整合を一覧表示し、保存前に利用者へ対応方針の選択を促すモーダル。
+ * 各 issue ごとの決定と再チェック操作をまとめて扱う。
+ */
+const IntegrityModal: FC<IntegrityModalProps> = ({
+  isOpen,
+  issues,
+  decisions,
+  onChangeDecision,
+  onApply,
+  onClose,
+  onRefresh
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const unresolvedCount = issues.filter((issue) => {
+    const selected = decisions[issue.id];
+    return !selected || selected === 'defer';
+  }).length;
+
+  return (
+    <div className="integrity-modal">
+      <div className="integrity-modal__backdrop" />
+      <div
+        className="integrity-modal__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="integrity-modal-title"
+      >
+        <header className="integrity-modal__header">
+          <div>
+            <h3 id="integrity-modal-title">整合性チェック</h3>
+            <p className="integrity-modal__subtitle">
+              workspace.json と各ブックファイルの不整合を確認し、どのように扱うかを選択してください。
+            </p>
+          </div>
+          <div className="integrity-modal__headerActions">
+            {onRefresh ? (
+              <button type="button" className="integrity-modal__refreshButton" onClick={onRefresh}>
+                再チェック
+              </button>
+            ) : null}
+            <button type="button" className="integrity-modal__closeButton" onClick={onClose}>
+              閉じる
+            </button>
+          </div>
+        </header>
+        <div className="integrity-modal__content">
+          {issues.length === 0 ? (
+            <p className="integrity-modal__empty">不整合は見つかりませんでした。</p>
+          ) : (
+            <div className="integrity-modal__issueList">
+              {issues.map((issue) => {
+                const defaultDecision = defaultDecisionForIssue(issue.supportedDecisions);
+                const selected = decisions[issue.id] ?? defaultDecision;
+                return (
+                  <section key={issue.id} className="integrity-modal__issue">
+                    <header className="integrity-modal__issueHeader">
+                      <span
+                        className={`integrity-modal__severity integrity-modal__severity--${issue.severity}`}
+                      >
+                        {severityLabel[issue.severity]}
+                      </span>
+                      <h4 className="integrity-modal__issueTitle">{issue.message}</h4>
+                    </header>
+                    <ul className="integrity-modal__options">
+                      {issue.supportedDecisions.map((decisionKey) => {
+                        const option = decisionOptions[decisionKey];
+                        if (!option) {
+                          return <Fragment key={decisionKey} />;
+                        }
+
+                        const isSelected = selected === decisionKey;
+                        return (
+                          <li key={decisionKey}>
+                            <label
+                              className={`integrity-modal__option${
+                                isSelected ? ' integrity-modal__option--active' : ''
+                              }`}
+                            >
+                              <input
+                                type="radio"
+                                name={`integrity-decision-${issue.id}`}
+                                value={decisionKey}
+                                checked={isSelected}
+                                onChange={() => onChangeDecision(issue.id, decisionKey)}
+                              />
+                              <div>
+                                <div className="integrity-modal__optionLabel">{option.label}</div>
+                                <div className="integrity-modal__optionDescription">
+                                  {option.description}
+                                </div>
+                              </div>
+                            </label>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </section>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <footer className="integrity-modal__footer">
+          <div className="integrity-modal__summary">
+            {issues.length === 0
+              ? '不整合は見つかりませんでした。閉じるボタンで確認を完了してください。'
+              : `未解決 ${unresolvedCount} 件 / 合計 ${issues.length} 件`}
+          </div>
+          <div className="integrity-modal__footerActions">
+            <button type="button" className="integrity-modal__secondaryButton" onClick={onClose}>
+              閉じる
+            </button>
+            <button
+              type="button"
+              className="integrity-modal__primaryButton"
+              onClick={onApply}
+              disabled={issues.length === 0}
+            >
+              選択を適用
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default IntegrityModal;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ interface SidebarProps {
   workspace: WorkspaceFile | null;
   books: BookFile[];
   selectedBookId?: string | null;
+  brokenBookIds?: ReadonlySet<string>;
   onSelectBook: (bookId: string) => void;
   onCreateBook?: () => void;
   onDeleteBook?: (bookId: string) => void;
@@ -16,6 +17,7 @@ const Sidebar: FC<SidebarProps> = ({
   workspace,
   books,
   selectedBookId,
+  brokenBookIds,
   onSelectBook,
   onCreateBook,
   onDeleteBook
@@ -39,20 +41,33 @@ const Sidebar: FC<SidebarProps> = ({
           {workspaceBooks.map((bookRef) => {
             const book = books.find((entry) => entry.book.id === bookRef.id);
             const isActive = bookRef.id === selectedBookId;
+            const isBroken = brokenBookIds?.has(bookRef.id) ?? false;
             const displayName = book?.book.name ?? trimExtension(bookRef.name);
+            const buttonClass = [
+              'sidebar__bookButton',
+              isActive ? 'sidebar__bookButton--active' : '',
+              isBroken ? 'sidebar__bookButton--broken' : ''
+            ]
+              .filter(Boolean)
+              .join(' ');
 
             return (
               <li key={bookRef.id} className="sidebar__bookItem">
                 <div className="sidebar__bookRow">
                   <button
                     type="button"
-                    className={`sidebar__bookButton${isActive ? ' sidebar__bookButton--active' : ''}`}
+                    className={buttonClass}
                     onClick={() => onSelectBook(bookRef.id)}
                   >
                     <span className="sidebar__bookEmoji" role="img" aria-hidden="true">
                       📄
                     </span>
                     <span>{displayName}</span>
+                    {isBroken ? (
+                      <span className="sidebar__bookBadge" aria-label="整合性チェックが必要">
+                        !
+                      </span>
+                    ) : null}
                   </button>
                   <button
                     type="button"

--- a/src/lib/workspace/integrity.test.ts
+++ b/src/lib/workspace/integrity.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import { detectIntegrityIssues, applyIntegrityRepairs } from './integrity';
+import { sampleBook, sampleWorkspace } from '../../samples/sampleData';
+import type { WorkspaceSnapshot } from '../../types/workspaceSnapshot';
+import type { BookFile } from '../../types/schema';
+import type { IntegrityDecisions } from '../../types/integrity';
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const createSnapshot = (): WorkspaceSnapshot => ({
+  workspace: {
+    filePath: '/workspace.json',
+    data: clone(sampleWorkspace)
+  },
+  books: [
+    {
+      filePath: '/books/book-001.json',
+      data: clone(sampleBook)
+    }
+  ]
+});
+
+describe('integrity checker', () => {
+  test('detectIntegrityIssues flags book id mismatch', () => {
+    const snapshot = createSnapshot();
+    snapshot.workspace.data.books[0].id = 'book-xyz';
+
+    const issues = detectIntegrityIssues(snapshot);
+    const mismatch = issues.find((issue) => issue.type === 'book-id-mismatch');
+
+    expect(mismatch).toBeDefined();
+    expect(mismatch?.bookRefId).toBe('book-xyz');
+    expect(mismatch?.bookFileId).toBe('book-001');
+  });
+
+  test('applyIntegrityRepairs aligns workspace to book file when useFile is selected', () => {
+    const snapshot = createSnapshot();
+    snapshot.workspace.data.books[0].id = 'book-xyz';
+
+    const issues = detectIntegrityIssues(snapshot);
+    const decisions: IntegrityDecisions = {};
+    issues.forEach((issue) => {
+      if (issue.type === 'book-id-mismatch') {
+        decisions[issue.id] = 'useFile';
+      }
+    });
+
+    const result = applyIntegrityRepairs(snapshot, issues, decisions);
+    expect(result.snapshot.workspace.data.books[0].id).toBe('book-001');
+    expect(result.bookIdReplacements['book-xyz']).toBe('book-001');
+  });
+
+  test('applyIntegrityRepairs resets missing active sheet', () => {
+    const snapshot = createSnapshot();
+    snapshot.workspace.data.books[0].activeSheetId = 'missing-sheet';
+
+    const issues = detectIntegrityIssues(snapshot);
+    const decisions: IntegrityDecisions = {};
+    issues.forEach((issue) => {
+      if (issue.type === 'missing-active-sheet') {
+        decisions[issue.id] = 'reset';
+      }
+    });
+
+    const result = applyIntegrityRepairs(snapshot, issues, decisions);
+    expect(result.snapshot.workspace.data.books[0].activeSheetId).toBe('sheet-001');
+    expect(result.sheetSelectionUpdates['book-001']).toBe('sheet-001');
+  });
+
+  test('applyIntegrityRepairs normalizes duplicate order values', () => {
+    const snapshot = createSnapshot();
+    const extraBook: BookFile = {
+      ...clone(sampleBook),
+      book: {
+        ...clone(sampleBook.book),
+        id: 'book-002',
+        name: '別のブック'
+      },
+      sheets: [
+        {
+          ...clone(sampleBook.sheets[0]),
+          id: 'sheet-002',
+          name: '別シート'
+        }
+      ]
+    };
+
+    snapshot.books.push({
+      filePath: '/books/book-002.json',
+      data: extraBook
+    });
+    snapshot.workspace.data.books = [
+      { ...snapshot.workspace.data.books[0], id: 'book-001', order: 0 },
+      {
+        ...snapshot.workspace.data.books[0],
+        id: 'book-002',
+        name: '別のブック.json',
+        order: 0,
+        dataPath: 'books/book-002.json'
+      }
+    ];
+
+    const issues = detectIntegrityIssues(snapshot);
+    const decisions: IntegrityDecisions = {};
+    issues
+      .filter((issue) => issue.type === 'invalid-order')
+      .forEach((issue) => {
+        decisions[issue.id] = 'normalize';
+      });
+
+    const result = applyIntegrityRepairs(snapshot, issues, decisions);
+    const orders = result.snapshot.workspace.data.books.map((book) => book.order);
+    expect(orders).toEqual([0, 1]);
+  });
+});

--- a/src/lib/workspace/integrity.ts
+++ b/src/lib/workspace/integrity.ts
@@ -1,0 +1,468 @@
+import type {
+  IntegrityDecisions,
+  IntegrityIssue,
+  IntegrityIssues
+} from '../../types/integrity';
+import type { BookReference } from '../../types/schema';
+import type { WorkspaceSnapshot } from '../../types/workspaceSnapshot';
+
+type BookOrderReason = 'duplicate' | 'non-finite';
+
+interface BookIdMismatchDetails {
+  workspaceBookIndex?: number;
+  workspaceId?: string;
+  fileId?: string;
+  filePath?: string;
+  dataPath?: string;
+}
+
+interface MissingActiveSheetDetails {
+  workspaceBookIndex?: number;
+  activeSheetId?: string;
+  availableSheetIds?: string[];
+}
+
+interface MissingFolderReferenceDetails {
+  workspaceBookIndex?: number;
+  folderId?: string;
+}
+
+interface InvalidOrderDetails {
+  workspaceBookIndex?: number;
+  folderId?: string | null;
+  order: number;
+  reason: BookOrderReason;
+}
+
+const cloneSnapshot = (value: WorkspaceSnapshot): WorkspaceSnapshot => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as WorkspaceSnapshot;
+};
+
+const normalizePath = (value: string): string => value.replace(/\\/g, '/');
+
+const resolveByDataPath = (snapshot: WorkspaceSnapshot, dataPath: string) => {
+  const normalized = normalizePath(dataPath);
+  return snapshot.books.find((entry) => normalizePath(entry.filePath).endsWith(normalized)) ?? null;
+};
+
+const resolveWorkspaceBookIndex = (books: BookReference[], bookId: string | undefined): number => {
+  if (!bookId) {
+    return -1;
+  }
+  return books.findIndex((ref) => ref.id === bookId);
+};
+
+const replaceIdInList = (list: string[] | undefined, fromId: string, toId: string): string[] | undefined => {
+  if (!list) {
+    return list;
+  }
+  let changed = false;
+  const next = list.map((id) => {
+    if (id === fromId) {
+      changed = true;
+      return toId;
+    }
+    return id;
+  });
+  return changed ? next : list;
+};
+
+const matchingIdFallback = (details: IntegrityIssue['details']): string | undefined => {
+  if (!details) {
+    return undefined;
+  }
+  if ('workspaceId' in details && typeof details.workspaceId === 'string') {
+    return details.workspaceId;
+  }
+  return undefined;
+};
+
+const normalizeBookOrders = (books: BookReference[]): void => {
+  const groups = new Map<string | null, BookReference[]>();
+
+  books.forEach((book) => {
+    const key = book.folderId ?? null;
+    const group = groups.get(key);
+    if (group) {
+      group.push(book);
+    } else {
+      groups.set(key, [book]);
+    }
+  });
+
+  groups.forEach((group) => {
+    group
+      .slice()
+      .sort((a, b) => {
+        if (a.order === b.order) {
+          return (a.id ?? '').localeCompare(b.id ?? '');
+        }
+        return a.order - b.order;
+      })
+      .forEach((book, index) => {
+        book.order = index;
+      });
+  });
+};
+
+export interface IntegrityRepairResult {
+  snapshot: WorkspaceSnapshot;
+  resolvedIssueIds: string[];
+  bookIdReplacements: Record<string, string>;
+  sheetSelectionUpdates: Record<string, string | null>;
+}
+
+const resolveCurrentBookId = (
+  originalId: string | undefined,
+  replacements: Map<string, string>
+): string | undefined => {
+  if (!originalId) {
+    return undefined;
+  }
+
+  let current = originalId;
+  const visited = new Set<string>();
+
+  while (replacements.has(current) && !visited.has(current)) {
+    visited.add(current);
+    const next = replacements.get(current);
+    if (!next) {
+      break;
+    }
+    current = next;
+  }
+
+  return current;
+};
+
+export const detectIntegrityIssues = (snapshot: WorkspaceSnapshot): IntegrityIssues => {
+  const issues: IntegrityIssue[] = [];
+  const workspaceData = snapshot.workspace.data;
+  const folderIds = new Set(workspaceData.folders.map((folder) => folder.id));
+
+  const duplicateTracker = new Map<string, number>();
+  const flaggedDuplicates = new Set<string>();
+
+  workspaceData.books.forEach((bookRef, index) => {
+    const matchingByPath = resolveByDataPath(snapshot, bookRef.dataPath);
+    const matchingById =
+      snapshot.books.find((entry) => entry.data.book.id === bookRef.id) ?? matchingByPath;
+
+    if (matchingByPath && matchingByPath.data.book.id !== bookRef.id) {
+      const issueId = `book-id-mismatch:${bookRef.id}:${matchingByPath.data.book.id}`;
+      issues.push({
+        id: issueId,
+        type: 'book-id-mismatch',
+        severity: 'error',
+        message: `workspace.json のブックID (${bookRef.id}) とファイル内の ID (${matchingByPath.data.book.id}) が一致しません。`,
+        bookRefId: bookRef.id,
+        bookFileId: matchingByPath.data.book.id,
+        supportedDecisions: ['useFile', 'useWorkspace', 'defer'],
+        details: {
+          workspaceBookIndex: index,
+          workspaceId: bookRef.id,
+          fileId: matchingByPath.data.book.id,
+          filePath: matchingByPath.filePath,
+          dataPath: bookRef.dataPath
+        } satisfies BookIdMismatchDetails
+      });
+    }
+
+    const activeSheetId = bookRef.activeSheetId;
+    if (matchingById && activeSheetId) {
+      const availableSheetIds = matchingById.data.sheets.map((sheet) => sheet.id);
+      if (!availableSheetIds.includes(activeSheetId)) {
+        issues.push({
+          id: `missing-active-sheet:${bookRef.id}`,
+          type: 'missing-active-sheet',
+          severity: 'warning',
+          message: `ブック ${bookRef.id} の activeSheetId (${activeSheetId}) がブックファイル内に存在しません。`,
+          bookRefId: bookRef.id,
+          bookFileId: matchingById.data.book.id,
+          supportedDecisions: ['reset', 'defer'],
+          details: {
+            workspaceBookIndex: index,
+            activeSheetId,
+            availableSheetIds
+          } satisfies MissingActiveSheetDetails
+        });
+      }
+    }
+
+    const folderId = bookRef.folderId ?? null;
+    if (folderId && !folderIds.has(folderId)) {
+      issues.push({
+        id: `missing-folder-reference:${bookRef.id}`,
+        type: 'missing-folder-reference',
+        severity: 'warning',
+        message: `ブック ${bookRef.id} の folderId (${folderId}) が folders に存在しません。`,
+        bookRefId: bookRef.id,
+        bookFileId: matchingById?.data.book.id,
+        supportedDecisions: ['reset', 'defer'],
+        details: {
+          workspaceBookIndex: index,
+          folderId
+        } satisfies MissingFolderReferenceDetails
+      });
+    }
+
+    const order = bookRef.order;
+    const orderKey = `${folderId ?? '__root__'}:${Number.isFinite(order) ? order : 'NaN'}`;
+    if (!Number.isFinite(order)) {
+      issues.push({
+        id: `invalid-order:${bookRef.id}`,
+        type: 'invalid-order',
+        severity: 'warning',
+        message: `ブック ${bookRef.id} の order の値 (${String(order)}) が数値ではありません。`,
+        bookRefId: bookRef.id,
+        bookFileId: matchingById?.data.book.id,
+        supportedDecisions: ['normalize', 'defer'],
+        details: {
+          workspaceBookIndex: index,
+          folderId,
+          order,
+          reason: 'non-finite'
+        } satisfies InvalidOrderDetails
+      });
+    } else if (duplicateTracker.has(orderKey)) {
+      const firstIndex = duplicateTracker.get(orderKey) ?? index;
+      if (!flaggedDuplicates.has(orderKey)) {
+        const firstRef = workspaceData.books[firstIndex];
+        issues.push({
+          id: `invalid-order:${firstRef.id}`,
+          type: 'invalid-order',
+          severity: 'warning',
+          message: `フォルダ ${folderId ?? '(root)'} で order=${order} が重複しています。`,
+          bookRefId: firstRef.id,
+          bookFileId: snapshot.books.find((entry) => entry.data.book.id === firstRef.id)?.data.book.id,
+          supportedDecisions: ['normalize', 'defer'],
+          details: {
+            workspaceBookIndex: firstIndex,
+            folderId,
+            order,
+            reason: 'duplicate'
+          } satisfies InvalidOrderDetails
+        });
+        flaggedDuplicates.add(orderKey);
+      }
+
+      issues.push({
+        id: `invalid-order:${bookRef.id}`,
+        type: 'invalid-order',
+        severity: 'warning',
+        message: `フォルダ ${folderId ?? '(root)'} で order=${order} が重複しています。`,
+        bookRefId: bookRef.id,
+        bookFileId: matchingById?.data.book.id,
+        supportedDecisions: ['normalize', 'defer'],
+        details: {
+          workspaceBookIndex: index,
+          folderId,
+          order,
+          reason: 'duplicate'
+        } satisfies InvalidOrderDetails
+      });
+    } else {
+      duplicateTracker.set(orderKey, index);
+    }
+  });
+
+  return issues;
+};
+
+export const applyIntegrityRepairs = (
+  snapshot: WorkspaceSnapshot,
+  issues: IntegrityIssues,
+  decisions: IntegrityDecisions
+): IntegrityRepairResult => {
+  const nextSnapshot = cloneSnapshot(snapshot);
+  const resolvedIssueIds: string[] = [];
+  const replacements = new Map<string, string>();
+  const bookIdReplacements: Record<string, string> = {};
+  const sheetSelectionUpdates: Record<string, string | null> = {};
+  let shouldNormalizeOrders = false;
+  let workspaceMutated = false;
+  let booksMutated = false;
+
+  const now = new Date().toISOString();
+
+  const registerReplacement = (fromId: string, toId: string) => {
+    replacements.set(fromId, toId);
+    bookIdReplacements[fromId] = toId;
+  };
+
+  const workspaceBooks = nextSnapshot.workspace.data.books;
+
+  issues.forEach((issue) => {
+    const decision = decisions[issue.id];
+    if (!decision || decision === 'defer') {
+      return;
+    }
+
+    if (issue.type === 'book-id-mismatch') {
+      const details = issue.details as BookIdMismatchDetails | undefined;
+
+      if (decision === 'useFile') {
+        const originalId =
+          details?.workspaceId ?? issue.bookRefId ?? matchingIdFallback(issue.details);
+        const newId = details?.fileId;
+        if (!originalId || !newId) {
+          return;
+        }
+
+        const currentId = resolveCurrentBookId(originalId, replacements) ?? originalId;
+        const bookIndex =
+          typeof details?.workspaceBookIndex === 'number'
+            ? details.workspaceBookIndex
+            : resolveWorkspaceBookIndex(workspaceBooks, currentId);
+
+        if (bookIndex === -1) {
+          return;
+        }
+
+        const previousId = workspaceBooks[bookIndex]?.id;
+        if (!previousId) {
+          return;
+        }
+
+        workspaceBooks[bookIndex] = {
+          ...workspaceBooks[bookIndex],
+          id: newId,
+          updatedAt: now
+        };
+
+        const settings = nextSnapshot.workspace.data.workspace.settings ?? {};
+        const nextRecentBookIds = replaceIdInList(settings.recentBookIds, previousId, newId);
+        nextSnapshot.workspace.data.workspace.settings = {
+          ...settings,
+          recentBookIds: nextRecentBookIds ?? settings.recentBookIds,
+          recentSheetIds: settings.recentSheetIds
+        };
+
+        registerReplacement(originalId, newId);
+        workspaceMutated = true;
+        resolvedIssueIds.push(issue.id);
+      } else if (decision === 'useWorkspace') {
+        const workspaceId =
+          resolveCurrentBookId(details?.workspaceId ?? issue.bookRefId, replacements) ??
+          details?.workspaceId ??
+          issue.bookRefId;
+        const fileId = details?.fileId;
+        const filePath = details?.filePath;
+        const targetEntry =
+          nextSnapshot.books.find((entry) => (filePath ? entry.filePath === filePath : false)) ??
+          nextSnapshot.books.find((entry) => entry.data.book.id === fileId);
+
+        if (!workspaceId || !targetEntry) {
+          return;
+        }
+
+        targetEntry.data = {
+          ...targetEntry.data,
+          book: {
+            ...targetEntry.data.book,
+            id: workspaceId,
+            updatedAt: now
+          }
+        };
+
+        replacements.set(fileId ?? workspaceId, workspaceId);
+        booksMutated = true;
+        resolvedIssueIds.push(issue.id);
+      }
+      return;
+    }
+
+    if (issue.type === 'missing-active-sheet' && decision === 'reset') {
+      const details = issue.details as MissingActiveSheetDetails | undefined;
+      const originalId = issue.bookRefId;
+      const currentId = resolveCurrentBookId(originalId, replacements) ?? originalId;
+      const bookIndex =
+        typeof details?.workspaceBookIndex === 'number'
+          ? details.workspaceBookIndex
+          : resolveWorkspaceBookIndex(workspaceBooks, currentId);
+
+      if (bookIndex === -1) {
+        return;
+      }
+
+      const availableSheetIds = details?.availableSheetIds ?? [];
+      const nextActiveSheetId = availableSheetIds[0] ?? null;
+
+      workspaceBooks[bookIndex] = {
+        ...workspaceBooks[bookIndex],
+        activeSheetId: nextActiveSheetId ?? undefined,
+        updatedAt: now
+      };
+
+      sheetSelectionUpdates[currentId ?? workspaceBooks[bookIndex].id] = nextActiveSheetId;
+      workspaceMutated = true;
+      resolvedIssueIds.push(issue.id);
+      return;
+    }
+
+    if (issue.type === 'missing-folder-reference' && decision === 'reset') {
+      const details = issue.details as MissingFolderReferenceDetails | undefined;
+      const originalId = issue.bookRefId;
+      const currentId = resolveCurrentBookId(originalId, replacements) ?? originalId;
+      const bookIndex =
+        typeof details?.workspaceBookIndex === 'number'
+          ? details.workspaceBookIndex
+          : resolveWorkspaceBookIndex(workspaceBooks, currentId);
+
+      if (bookIndex === -1) {
+        return;
+      }
+
+      workspaceBooks[bookIndex] = {
+        ...workspaceBooks[bookIndex],
+        folderId: null,
+        updatedAt: now
+      };
+
+      workspaceMutated = true;
+      resolvedIssueIds.push(issue.id);
+      return;
+    }
+
+    if (issue.type === 'invalid-order' && decision === 'normalize') {
+      shouldNormalizeOrders = true;
+      resolvedIssueIds.push(issue.id);
+    }
+  });
+
+  if (shouldNormalizeOrders) {
+    normalizeBookOrders(nextSnapshot.workspace.data.books);
+    workspaceMutated = true;
+  }
+
+  if (workspaceMutated) {
+    nextSnapshot.workspace.data = {
+      ...nextSnapshot.workspace.data,
+      workspace: {
+        ...nextSnapshot.workspace.data.workspace,
+        updatedAt: now
+      },
+      books: [...nextSnapshot.workspace.data.books]
+    };
+  }
+
+  if (booksMutated) {
+    nextSnapshot.books = nextSnapshot.books.map((entry) => ({
+      ...entry,
+      data: {
+        ...entry.data,
+        book: { ...entry.data.book }
+      }
+    }));
+  }
+
+  return {
+    snapshot: nextSnapshot,
+    resolvedIssueIds,
+    bookIdReplacements,
+    sheetSelectionUpdates
+  };
+};

--- a/src/types/integrity.ts
+++ b/src/types/integrity.ts
@@ -1,0 +1,29 @@
+export type IntegrityIssueType =
+  | 'book-id-mismatch'
+  | 'missing-active-sheet'
+  | 'missing-folder-reference'
+  | 'invalid-order';
+
+export type IntegritySeverity = 'error' | 'warning';
+
+export type IntegrityDecisionKey =
+  | 'useFile'
+  | 'useWorkspace'
+  | 'reset'
+  | 'normalize'
+  | 'defer';
+
+export interface IntegrityIssue {
+  id: string;
+  type: IntegrityIssueType;
+  severity: IntegritySeverity;
+  message: string;
+  bookRefId?: string;
+  bookFileId?: string;
+  supportedDecisions: IntegrityDecisionKey[];
+  details?: Record<string, unknown>;
+}
+
+export type IntegrityIssues = IntegrityIssue[];
+
+export type IntegrityDecisions = Record<string, IntegrityDecisionKey>;


### PR DESCRIPTION
## 背景／目的
- workspace.json とブックファイルの不整合があってもそのまま保存できてしまい、破損状態を永続化してしまう課題があった。
- ユーザーが状況を把握しながら対話的に修復内容を選べる UI を用意したかった。

## 主な変更点
- `IntegrityIssue` 系の型を追加し、整合性チェック結果とユーザー選択を保持できるようにした。
- `detectIntegrityIssues` / `applyIntegrityRepairs` を実装し、ID 不一致・activeSheet 欠落・フォルダ参照切れ・order 重複を検出／修復。
- Zustand ストアに `integrityIssues` / `integrityDecisions` を追加し、Undo/Redo と連携して常に最新状態を維持。
- 整合性チェックモーダルを新設し、保存前には未解決 issue があればブロック／警告するようにした。
- サイドバーに警告バッジを表示し、どのブックに問題が残っているか分かるようにした。
- Bun のユニットテストを追加し、主要な修復ケースを検証。

## 動作確認
- `bun test`
- ブック ID を意図的に不一致にして再読み込み → モーダルが開き、保存できないことを確認。
- モーダルで「ファイルに合わせる」を選択 → ブック ID が揃い、保存できるようになることを確認。
