### PR TITLE
chore: Bunテスト用の暫定型定義を追加

### DIFF
--- a/src/types/bun-test.d.ts
+++ b/src/types/bun-test.d.ts
@@ -1,0 +1,6 @@
+// NOTE: Bun の公式型定義が未提供のため、tsc が bundle 時に 'bun:test' を解決できるよう最低限の宣言を置いている。
+declare module 'bun:test' {
+  export const describe: (...args: any[]) => void;
+  export const test: (...args: any[]) => void;
+  export const expect: any;
+}


### PR DESCRIPTION
## 背景／目的
- `integrity.test.ts` で `import { describe, expect, test } from 'bun:test';` を記述すると、`bun run build` 時に TypeScript が `bun:test` を解決できず `TS2307` が発生していた。
- Bun 公式の型定義がまだ提供されていないため、簡易的な宣言ファイルを追加してビルドを通す必要がある。

## 主な変更点
- `src/types/bun-test.d.ts` を追加し、`describe` / `test` / `expect` の最低限の宣言を定義。
- ファイル先頭に暫定対応である旨のコメントを記載し、今後の置き換え余地を明示。

## 動作確認
- `bun run build`
