### PR TITLE
feat: 新規ワークスペース作成フローを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ dist-ssr
 
 # Private docs
 OBSIDIAN.md
+
+# Rust build artifacts
+target
+src-tauri/target

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3449,6 +3449,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "time",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,3 +23,5 @@ tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+time = { version = "0.3", features = ["formatting"] }
+uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 mod workspace;
 
-use workspace::{delete_book_file, load_workspace_snapshot, save_workspace_snapshot};
+use workspace::{
+    create_workspace, delete_book_file, load_workspace_snapshot, save_workspace_snapshot,
+};
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
@@ -15,6 +17,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             greet,
+            create_workspace,
             load_workspace_snapshot,
             save_workspace_snapshot,
             delete_book_file

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
+use time::format_description::well_known::Iso8601;
+use time::OffsetDateTime;
+use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FilePayload {
@@ -14,6 +17,25 @@ pub struct FilePayload {
 pub struct WorkspaceSnapshotPayload {
     pub workspace: FilePayload,
     pub books: Vec<FilePayload>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateWorkspaceRequest {
+    pub parent_dir: String,
+    pub workspace_name: String,
+    #[serde(default = "default_include_sample")]
+    pub include_sample: bool,
+}
+
+const WORKSPACE_NAME_MIN: usize = 1;
+const WORKSPACE_NAME_MAX: usize = 48;
+const SCHEMA_VERSION: &str = "1.0.0";
+const SAMPLE_BOOK_TITLE: &str = "スターターブック";
+const SAMPLE_SHEET_TITLE: &str = "サンプルシート";
+
+fn default_include_sample() -> bool {
+    true
 }
 
 fn read_json_file(path: &Path) -> Result<Value, String> {
@@ -64,14 +86,238 @@ fn resolve_books(
         let absolute_path = workspace_dir.join(data_path);
         let book_data = read_json_file(&absolute_path)?;
         result.push(FilePayload {
-            file_path: absolute_path
-                .to_string_lossy()
-                .into_owned(),
+            file_path: absolute_path.to_string_lossy().into_owned(),
             data: book_data,
         });
     }
 
     Ok(result)
+}
+
+#[tauri::command]
+pub fn create_workspace(
+    request: CreateWorkspaceRequest,
+) -> Result<WorkspaceSnapshotPayload, String> {
+    let parent_path = PathBuf::from(&request.parent_dir);
+    if !parent_path.exists() {
+        return Err("指定されたフォルダが存在しません。".into());
+    }
+    if !parent_path.is_dir() {
+        return Err("フォルダを選択してください。".into());
+    }
+
+    let normalized_name = validate_workspace_name(&request.workspace_name)?;
+    let workspace_dir = parent_path.join(&normalized_name);
+    if workspace_dir.exists() {
+        return Err("同じ名前のワークスペースフォルダが既に存在します。".into());
+    }
+
+    fs::create_dir(&workspace_dir)
+        .map_err(|err| format!("{} の作成に失敗しました: {}", workspace_dir.display(), err))?;
+    fs::create_dir_all(workspace_dir.join("books"))
+        .map_err(|err| format!("books ディレクトリの作成に失敗しました: {}", err))?;
+    fs::create_dir_all(workspace_dir.join("thumbs"))
+        .map_err(|err| format!("thumbs ディレクトリの作成に失敗しました: {}", err))?;
+
+    let documents = build_workspace_documents(&normalized_name, request.include_sample);
+    let workspace_path = workspace_dir.join("workspace.json");
+    write_json_file(&workspace_path, &documents.workspace)?;
+
+    for book in documents.books {
+        let absolute = workspace_dir.join(book.relative_path);
+        write_json_file(&absolute, &book.data)?;
+    }
+
+    load_workspace_snapshot(workspace_path.to_string_lossy().into_owned())
+}
+
+fn now_iso_string() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Iso8601::DEFAULT)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+fn generate_id(prefix: &str) -> String {
+    format!("{}-{}", prefix, Uuid::new_v4())
+}
+
+fn has_leading_or_trailing_space_or_dot(value: &str) -> bool {
+    let mut chars = value.chars();
+    let starts_invalid = chars
+        .next()
+        .map(|c| c.is_whitespace() || c == '.')
+        .unwrap_or(false);
+    let ends_invalid = value
+        .chars()
+        .rev()
+        .next()
+        .map(|c| c.is_whitespace() || c == '.')
+        .unwrap_or(false);
+    starts_invalid || ends_invalid
+}
+
+fn contains_control_char(value: &str) -> bool {
+    value.chars().any(|c| c.is_control())
+}
+
+fn contains_forbidden_char(value: &str) -> bool {
+    value
+        .chars()
+        .any(|c| matches!(c, '\\' | '/' | ':' | '*' | '?' | '"' | '<' | '>' | '|'))
+}
+
+fn is_reserved_name(value: &str) -> bool {
+    const RESERVED: [&str; 22] = [
+        "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+        "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+    ];
+
+    if value == "." || value == ".." {
+        return true;
+    }
+
+    RESERVED.contains(&value.to_ascii_lowercase().as_str())
+}
+
+fn validate_workspace_name(input: &str) -> Result<String, String> {
+    if input.is_empty() {
+        return Err("名前を入力してください。".into());
+    }
+
+    let normalized = input.trim();
+    if normalized.is_empty() {
+        return Err("名前を入力してください。".into());
+    }
+
+    if normalized.len() < WORKSPACE_NAME_MIN {
+        return Err(format!(
+            "{}文字以上で入力してください。",
+            WORKSPACE_NAME_MIN
+        ));
+    }
+
+    if normalized.len() > WORKSPACE_NAME_MAX {
+        return Err(format!(
+            "{}文字以内で入力してください。",
+            WORKSPACE_NAME_MAX
+        ));
+    }
+
+    if has_leading_or_trailing_space_or_dot(input) {
+        return Err("先頭と末尾に空白またはドットは使用できません。".into());
+    }
+
+    if contains_control_char(normalized) {
+        return Err("制御文字は使用できません。".into());
+    }
+
+    if contains_forbidden_char(normalized) {
+        return Err("\\ / : * ? \" < > | などの記号は使用できません。".into());
+    }
+
+    if is_reserved_name(normalized) {
+        return Err("この名称はファイルシステムで予約されているため使用できません。".into());
+    }
+
+    Ok(normalized.to_string())
+}
+
+struct BookDocument {
+    relative_path: String,
+    data: Value,
+}
+
+struct WorkspaceDocuments {
+    workspace: Value,
+    books: Vec<BookDocument>,
+}
+
+fn build_workspace_documents(name: &str, include_sample: bool) -> WorkspaceDocuments {
+    let now = now_iso_string();
+    let workspace_id = generate_id("workspace");
+
+    let mut books: Vec<Value> = Vec::new();
+    let mut book_documents: Vec<BookDocument> = Vec::new();
+    let mut recent_book_ids: Vec<String> = Vec::new();
+    let mut recent_sheet_ids: Vec<String> = Vec::new();
+
+    if include_sample {
+        let book_id = generate_id("book");
+        let sheet_id = generate_id("sheet");
+        let data_path = format!("books/{}.json", book_id);
+
+        books.push(json!({
+            "id": book_id.clone(),
+            "name": format!("{SAMPLE_BOOK_TITLE}.json"),
+            "folderId": Value::Null,
+            "order": 0,
+            "dataPath": data_path,
+            "activeSheetId": sheet_id.clone(),
+            "createdAt": now,
+            "updatedAt": now
+        }));
+
+        book_documents.push(BookDocument {
+            relative_path: data_path,
+            data: json!({
+                "schemaVersion": SCHEMA_VERSION,
+                "book": {
+                    "id": book_id.clone(),
+                    "name": SAMPLE_BOOK_TITLE,
+                    "createdAt": now,
+                    "updatedAt": now,
+                    "properties": {
+                        "defaultFormat": "plain",
+                        "locked": false
+                    }
+                },
+                "sheets": [
+                    {
+                        "id": sheet_id.clone(),
+                        "name": SAMPLE_SHEET_TITLE,
+                        "gridSize": {"rows": 100, "cols": 26},
+                        "settings": {"locked": false},
+                        "rows": {
+                            "1": {
+                                "A": {"value": "タイトル", "type": "string"},
+                                "B": {"value": "ステータス", "type": "string"}
+                            },
+                            "2": {
+                                "A": {"value": "サンプル項目", "type": "string"},
+                                "B": {"value": "進行中", "type": "string"}
+                            }
+                        }
+                    }
+                ]
+            }),
+        });
+
+        recent_book_ids.push(book_id);
+        recent_sheet_ids.push(sheet_id);
+    }
+
+    let workspace = json!({
+        "schemaVersion": SCHEMA_VERSION,
+        "workspace": {
+            "id": workspace_id,
+            "name": name,
+            "createdAt": now,
+            "updatedAt": now,
+            "settings": {
+                "theme": "system",
+                "sidebarWidth": 280,
+                "recentBookIds": recent_book_ids,
+                "recentSheetIds": recent_sheet_ids
+            }
+        },
+        "folders": [],
+        "books": books
+    });
+
+    WorkspaceDocuments {
+        workspace,
+        books: book_documents,
+    }
 }
 
 #[tauri::command]

--- a/src/App.css
+++ b/src/App.css
@@ -599,6 +599,37 @@ button {
   box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
 }
 
+.main-view__emptyActions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.main-view__secondaryButton {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #1f2937;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.main-view__secondaryButton:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.main-view__secondaryButton:not(:disabled):hover {
+  background: #f8fafc;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+}
+
 .main-view__note {
   font-size: 0.85rem;
   color: #9ca3af;
@@ -962,6 +993,127 @@ button {
 
 .integrity-modal__primaryButton:not(:disabled):hover {
   background: #1d4ed8;
+}
+
+.workspace-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+}
+
+.workspace-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.workspace-dialog__panel {
+  position: relative;
+  margin: 10vh auto 0;
+  width: min(420px, calc(100% - 32px));
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.25);
+  padding: 24px;
+}
+
+.workspace-dialog__header {
+  margin-bottom: 12px;
+}
+
+.workspace-dialog__header h3 {
+  margin: 0 0 6px;
+  font-size: 1.2rem;
+  color: #111827;
+}
+
+.workspace-dialog__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.workspace-dialog__content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.workspace-dialog__label {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 6px;
+}
+
+.workspace-dialog__input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.workspace-dialog__input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.workspace-dialog__input--error {
+  border-color: #f87171;
+}
+
+.workspace-dialog__error {
+  margin: 6px 0 0;
+  font-size: 0.85rem;
+  color: #b91c1c;
+}
+
+.workspace-dialog__footer {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.workspace-dialog__secondaryButton,
+.workspace-dialog__primaryButton {
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.workspace-dialog__secondaryButton {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.workspace-dialog__secondaryButton:not(:disabled):hover {
+  background: #d1d5db;
+}
+
+.workspace-dialog__primaryButton {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.workspace-dialog__primaryButton:not(:disabled):hover {
+  background: #1d4ed8;
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
+}
+
+.workspace-dialog__secondaryButton:disabled,
+.workspace-dialog__primaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 @media (max-width: 960px) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,18 +2,22 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import SheetGrid from './components/SheetGrid';
 import Sidebar from './components/Sidebar';
 import SheetTabs from './components/SheetTabs';
+import WorkspaceNameDialog from './components/WorkspaceNameDialog';
 import { isTauri } from './lib/env';
 import {
   openWorkspaceFromDialog,
   saveWorkspaceSnapshot,
   showErrorDialog,
-  deleteBookFile
+  deleteBookFile,
+  createWorkspaceAtDirectory,
+  selectWorkspaceParentDirectory
 } from './lib/tauri/workspaceBridge';
 import type { BookFile } from './types/schema';
 import { useWorkspaceStore, type CellUpdate } from './state/workspaceStore';
 import IntegrityModal from './components/IntegrityModal';
 import type { IntegrityDecisionKey } from './types/integrity';
 import './App.css';
+import { validateWorkspaceName } from './lib/validation/workspaceName';
 
 const toErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
@@ -54,6 +58,22 @@ function App() {
   const skipSheetBlurCommitRef = useRef(false);
   const [isIntegrityModalOpen, setIntegrityModalOpen] = useState(false);
   const previousIssueCountRef = useRef(integrityIssues.length);
+  const [isWorkspaceDialogOpen, setWorkspaceDialogOpen] = useState(false);
+  const [workspaceNameInput, setWorkspaceNameInput] = useState('');
+  const [workspaceNameTouched, setWorkspaceNameTouched] = useState(false);
+  const [workspaceDialogSubmitted, setWorkspaceDialogSubmitted] = useState(false);
+  const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
+
+  const workspaceNameValidation = useMemo(
+    () => validateWorkspaceName(workspaceNameInput),
+    [workspaceNameInput]
+  );
+
+  const shouldShowWorkspaceNameError =
+    (workspaceNameTouched || workspaceDialogSubmitted) && !workspaceNameValidation.ok;
+  const workspaceNameError = shouldShowWorkspaceNameError
+    ? workspaceNameValidation.issues[0]?.message ?? null
+    : null;
   const handleOpenWorkspace = useCallback(async () => {
     if (!isTauri) return;
     setBusyState('loading');
@@ -68,6 +88,59 @@ function App() {
       setBusyState('idle');
     }
   }, [loadWorkspace, setBusyState]);
+
+  const handleLaunchWorkspaceDialog = useCallback(() => {
+    if (!isTauri) return;
+    setWorkspaceDialogOpen(true);
+    setWorkspaceNameInput('');
+    setWorkspaceNameTouched(false);
+    setWorkspaceDialogSubmitted(false);
+  }, []);
+
+  const handleWorkspaceNameChange = useCallback((value: string) => {
+    setWorkspaceNameTouched(true);
+    setWorkspaceNameInput(value);
+  }, []);
+
+  const handleWorkspaceDialogCancel = useCallback(() => {
+    setWorkspaceDialogOpen(false);
+    setWorkspaceDialogSubmitted(false);
+    setWorkspaceNameTouched(false);
+    setWorkspaceNameInput('');
+  }, []);
+
+  const handleWorkspaceDialogSubmit = useCallback(async () => {
+    if (!isTauri) return;
+    setWorkspaceDialogSubmitted(true);
+    setWorkspaceNameTouched(true);
+
+    if (!workspaceNameValidation.ok || !workspaceNameValidation.normalized) {
+      return;
+    }
+
+    setIsCreatingWorkspace(true);
+    setBusyState('loading');
+    try {
+      const parentDir = await selectWorkspaceParentDirectory();
+      if (!parentDir) {
+        return;
+      }
+      const snapshot = await createWorkspaceAtDirectory(
+        parentDir,
+        workspaceNameValidation.normalized
+      );
+      loadWorkspace(snapshot);
+      setWorkspaceDialogOpen(false);
+      setWorkspaceDialogSubmitted(false);
+      setWorkspaceNameTouched(false);
+      setWorkspaceNameInput('');
+    } catch (error) {
+      await showErrorDialog('ワークスペースの作成に失敗しました', toErrorMessage(error));
+    } finally {
+      setIsCreatingWorkspace(false);
+      setBusyState('idle');
+    }
+  }, [loadWorkspace, setBusyState, workspaceNameValidation]);
 
   const handleSaveWorkspace = useCallback(async () => {
     if (!isTauri) return;
@@ -563,14 +636,24 @@ function App() {
       <h2>ワークスペースを開いてください</h2>
       <p>既存のワークスペースフォルダを選択すると、workspace.json とブックファイルを読み込みます。</p>
       {isTauri ? (
-        <button
-          type="button"
-          className="main-view__primaryButton"
-          onClick={handleOpenWorkspace}
-          disabled={busyState === 'loading'}
-        >
-          {busyState === 'loading' ? '読み込み中…' : 'ワークスペースを開く'}
-        </button>
+        <div className="main-view__emptyActions">
+          <button
+            type="button"
+            className="main-view__primaryButton"
+            onClick={handleOpenWorkspace}
+            disabled={busyState === 'loading'}
+          >
+            {busyState === 'loading' ? '読み込み中…' : 'ワークスペースを開く'}
+          </button>
+          <button
+            type="button"
+            className="main-view__secondaryButton"
+            onClick={handleLaunchWorkspaceDialog}
+            disabled={busyState === 'loading' || isCreatingWorkspace}
+          >
+            新規ワークスペースを作成
+          </button>
+        </div>
       ) : (
         <p className="main-view__note">ブラウザプレビューではサンプルデータのみ閲覧できます。</p>
       )}
@@ -695,6 +778,14 @@ function App() {
                   <button
                     type="button"
                     className="main-view__actionButton"
+                    onClick={handleLaunchWorkspaceDialog}
+                    disabled={busyState === 'loading' || isCreatingWorkspace}
+                  >
+                    新規ワークスペース
+                  </button>
+                  <button
+                    type="button"
+                    className="main-view__actionButton"
                     onClick={handleOpenWorkspace}
                     disabled={busyState === 'loading'}
                   >
@@ -781,6 +872,15 @@ function App() {
           )}
         </div>
       </section>
+      <WorkspaceNameDialog
+        isOpen={isWorkspaceDialogOpen}
+        value={workspaceNameInput}
+        error={workspaceNameError}
+        isSubmitting={isCreatingWorkspace}
+        onChange={handleWorkspaceNameChange}
+        onSubmit={handleWorkspaceDialogSubmit}
+        onCancel={handleWorkspaceDialogCancel}
+      />
       <IntegrityModal
         isOpen={isIntegrityModalOpen}
         issues={integrityIssues}

--- a/src/components/WorkspaceNameDialog.tsx
+++ b/src/components/WorkspaceNameDialog.tsx
@@ -1,0 +1,91 @@
+import { type FC, useEffect, useRef } from 'react';
+
+interface WorkspaceNameDialogProps {
+  isOpen: boolean;
+  value: string;
+  error?: string | null;
+  isSubmitting?: boolean;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+const WorkspaceNameDialog: FC<WorkspaceNameDialogProps> = ({
+  isOpen,
+  value,
+  error,
+  isSubmitting,
+  onChange,
+  onSubmit,
+  onCancel
+}) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="workspace-dialog">
+      <div className="workspace-dialog__backdrop" />
+      <div
+        className="workspace-dialog__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="workspace-dialog-title"
+      >
+        <header className="workspace-dialog__header">
+          <h3 id="workspace-dialog-title">新しいワークスペース</h3>
+          <p className="workspace-dialog__subtitle">
+            ワークスペース名を入力し、保存先フォルダを選択してください。
+          </p>
+        </header>
+        <div className="workspace-dialog__content">
+          <label className="workspace-dialog__label" htmlFor="workspace-name-input">
+            ワークスペース名
+          </label>
+          <input
+            id="workspace-name-input"
+            ref={inputRef}
+            type="text"
+            className={
+              error ? 'workspace-dialog__input workspace-dialog__input--error' : 'workspace-dialog__input'
+            }
+            placeholder="例: 個人プロジェクト"
+            value={value}
+            onChange={(event) => onChange(event.currentTarget.value)}
+            disabled={isSubmitting}
+          />
+          {error ? <p className="workspace-dialog__error">{error}</p> : null}
+        </div>
+        <footer className="workspace-dialog__footer">
+          <button
+            type="button"
+            className="workspace-dialog__secondaryButton"
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            className="workspace-dialog__primaryButton"
+            onClick={onSubmit}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? '確認中…' : '作成先を選ぶ'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceNameDialog;

--- a/src/lib/tauri/workspaceBridge.ts
+++ b/src/lib/tauri/workspaceBridge.ts
@@ -52,11 +52,11 @@ const normalizeSnapshot = (snapshot: WorkspaceSnapshotDto): WorkspaceSnapshot =>
   books: snapshot.books.map(normalizeBook)
 });
 
-export const selectWorkspaceDirectory = async (): Promise<string | null> => {
+const selectDirectory = async (title: string): Promise<string | null> => {
   const selection = await open({
     directory: true,
     multiple: false,
-    title: 'ワークスペースフォルダを選択'
+    title
   });
 
   if (selection === null) {
@@ -65,6 +65,13 @@ export const selectWorkspaceDirectory = async (): Promise<string | null> => {
 
   return Array.isArray(selection) ? selection[0] : selection;
 };
+
+export const selectWorkspaceDirectory = (): Promise<string | null> => {
+  return selectDirectory('ワークスペースフォルダを選択');
+};
+
+export const selectWorkspaceParentDirectory = (): Promise<string | null> =>
+  selectDirectory('ワークスペースを作成するフォルダを選択');
 
 export const resolveWorkspaceFilePath = async (path: string): Promise<string> => {
   if (path.toLowerCase().endsWith('workspace.json')) {
@@ -84,6 +91,21 @@ export const saveWorkspaceSnapshot = async (
   snapshot: WorkspaceSnapshot
 ): Promise<void> => {
   await invoke('save_workspace_snapshot', { snapshot });
+};
+
+export const createWorkspaceAtDirectory = async (
+  parentDir: string,
+  workspaceName: string,
+  includeSample = true
+): Promise<WorkspaceSnapshot> => {
+  const dto = await invoke<WorkspaceSnapshotDto>('create_workspace', {
+    request: {
+      parentDir,
+      workspaceName,
+      includeSample
+    }
+  });
+  return normalizeSnapshot(dto);
 };
 
 export const deleteBookFile = async (path: string): Promise<void> => {

--- a/src/lib/validation/workspaceName.test.ts
+++ b/src/lib/validation/workspaceName.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  validateWorkspaceName,
+  WORKSPACE_NAME_MAX,
+  WORKSPACE_NAME_MIN
+} from './workspaceName';
+
+describe('validateWorkspaceName', () => {
+  test('ASCII文字だけの名前を受け付ける', () => {
+    const result = validateWorkspaceName('Project Alpha');
+    expect(result.ok).toBe(true);
+    expect(result.normalized).toBe('Project Alpha');
+    expect(result.issues).toHaveLength(0);
+  });
+
+  test('マルチバイト文字を受け付ける', () => {
+    const result = validateWorkspaceName('表計算チーム');
+    expect(result.ok).toBe(true);
+    expect(result.normalized).toBe('表計算チーム');
+  });
+
+  test('文字列以外の入力は拒否する', () => {
+    const result = validateWorkspaceName(undefined);
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]?.code).toBe('required');
+  });
+
+  test('空白だけの文字列は拒否する', () => {
+    const result = validateWorkspaceName('   ');
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'required')).toBe(true);
+  });
+
+  test('上限文字数を超えた名前は拒否する', () => {
+    const longName = 'a'.repeat(WORKSPACE_NAME_MAX + 1);
+    const result = validateWorkspaceName(longName);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'too_long')).toBe(true);
+  });
+
+  test('先頭・末尾の空白やドットを含む名前は拒否する', () => {
+    const cases = [
+      ' leading blank',
+      'trailing blank ',
+      '.dotstart',
+      'dotend.',
+      '.both.',
+      ' both ',
+      ' mixed. '
+    ];
+
+    for (const fileName of cases) {
+      const result = validateWorkspaceName(fileName);
+      expect(result.ok).toBe(false);
+      expect(
+        result.issues.some((issue) => issue.code === 'leading_trailing_space_or_dot')
+    ).toBe(true);
+    };
+  });
+
+  test('制御文字を含む名前は拒否する', () => {
+    const result = validateWorkspaceName('name\u0007');
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'control_char')).toBe(true);
+  });
+
+  test('禁止記号を含む名前は拒否する', () => {
+    const result = validateWorkspaceName('name:name');
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'forbidden_char')).toBe(true);
+  });
+
+  test('制御文字と禁止記号の両方を含む名前は両方検知する', () => {
+    const result = validateWorkspaceName('invalid\n:name');
+    const codes = result.issues.map((issue) => issue.code);
+    expect(codes).toContain('control_char');
+    expect(codes).toContain('forbidden_char');
+  });
+
+  test('予約語やドットのみの名前は拒否する', () => {
+    const dotResult = validateWorkspaceName('..');
+    const deviceResult = validateWorkspaceName('CON');
+    expect(dotResult.ok).toBe(false);
+    expect(deviceResult.ok).toBe(false);
+    expect(deviceResult.issues.some((issue) => issue.code === 'reserved_name')).toBe(true);
+  });
+
+  test('検証が通れば正規化済みの文字列を返す', () => {
+    const name = 'My Workspace';
+    const result = validateWorkspaceName(name);
+    expect(result.ok).toBe(true);
+    expect(result.normalized).toBe(name);
+  });
+
+  test('最小文字数違反を検知できる', () => {
+    expect(WORKSPACE_NAME_MIN).toBe(1);
+    const result = validateWorkspaceName('');
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'required')).toBe(true);
+  });
+});

--- a/src/lib/validation/workspaceName.ts
+++ b/src/lib/validation/workspaceName.ts
@@ -1,0 +1,139 @@
+const RESERVED_DEVICE_NAMES = new Set(
+  [
+    'con',
+    'prn',
+    'aux',
+    'nul',
+    'com1',
+    'com2',
+    'com3',
+    'com4',
+    'com5',
+    'com6',
+    'com7',
+    'com8',
+    'com9',
+    'lpt1',
+    'lpt2',
+    'lpt3',
+    'lpt4',
+    'lpt5',
+    'lpt6',
+    'lpt7',
+    'lpt8',
+    'lpt9'
+  ]
+);
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
+const FORBIDDEN_CHAR_PATTERN = /[\\/:*?"<>|]/;
+
+export const WORKSPACE_NAME_MIN = 1;
+export const WORKSPACE_NAME_MAX = 48;
+
+export type WorkspaceNameIssueCode =
+  | 'required'
+  | 'too_short'
+  | 'too_long'
+  | 'leading_trailing_space_or_dot'
+  | 'control_char'
+  | 'forbidden_char'
+  | 'reserved_name';
+
+export interface WorkspaceNameIssue {
+  code: WorkspaceNameIssueCode;
+  message: string;
+}
+
+export interface WorkspaceNameValidationResult {
+  ok: boolean;
+  normalized?: string;
+  issues: WorkspaceNameIssue[];
+}
+
+const hasLeadingOrTrailingSpaceOrDot = (value: string): boolean => {
+  if (value.length === 0) {
+    return false;
+  }
+  const startsWithInvalid = value[0] === '.' || value[0].trim().length === 0;
+  const endsWithInvalid = value[value.length - 1] === '.' || value[value.length - 1].trim().length === 0;
+  return startsWithInvalid || endsWithInvalid;
+};
+
+const isReservedName = (value: string): boolean => {
+  if (value === '.' || value === '..') {
+    return true;
+  }
+  return RESERVED_DEVICE_NAMES.has(value.toLowerCase());
+};
+
+export const validateWorkspaceName = (input: unknown): WorkspaceNameValidationResult => {
+  const issues: WorkspaceNameIssue[] = [];
+
+  if (typeof input !== 'string') {
+    return {
+      ok: false,
+      issues: [
+        {
+          code: 'required',
+          message: '名前を入力してください。'
+        }
+      ]
+    };
+  }
+
+  const normalized = input.trim();
+
+  if (normalized.length === 0) {
+    issues.push({
+      code: 'required',
+      message: '名前を入力してください。'
+    });
+  }
+
+  if (normalized.length > 0 && normalized.length < WORKSPACE_NAME_MIN) {
+    issues.push({
+      code: 'too_short',
+      message: `${WORKSPACE_NAME_MIN}文字以上で入力してください。`
+    });
+  }
+
+  if (normalized.length > WORKSPACE_NAME_MAX) {
+    issues.push({
+      code: 'too_long',
+      message: `${WORKSPACE_NAME_MAX}文字以内で入力してください。`
+    });
+  }
+
+  if (hasLeadingOrTrailingSpaceOrDot(input)) {
+    issues.push({
+      code: 'leading_trailing_space_or_dot',
+      message: '先頭と末尾に空白またはドットは使用できません。'
+    });
+  }
+
+  if (CONTROL_CHAR_PATTERN.test(normalized)) {
+    issues.push({
+      code: 'control_char',
+      message: '制御文字は使用できません。'
+    });
+  }
+
+  if (FORBIDDEN_CHAR_PATTERN.test(normalized)) {
+    issues.push({
+      code: 'forbidden_char',
+      message: '\\ / : * ? " < > | などの記号は使用できません。'
+    });
+  }
+
+  if (isReservedName(normalized)) {
+    issues.push({
+      code: 'reserved_name',
+      message: 'この名称はファイルシステムで予約されているため使用できません。'
+    });
+  }
+
+  return issues.length === 0
+    ? { ok: true, normalized, issues }
+    : { ok: false, issues };
+};


### PR DESCRIPTION
Closes #69

## 概要
- 新規ワークスペース作成フローを追加し、UIから作成→初期データ生成→読み込みまで完了できるようにする

## 背景
- 未選択状態からワークスペースを新規作成する導線が必要だったため

## 主要な変更点
- Tauri側に create_workspace コマンドとサンプル初期データ生成を追加
- ワークスペース名入力モーダルと新規作成ボタンを追加
- ブリッジ層に作成コマンド呼び出しとフォルダ選択処理を追加
- ワークスペース名バリデーションを共通ヘルパー化し、テストを追加

## 動作確認 / テスト結果
- `cargo fmt`
- `cargo check`（src-tauri）
- `bun test`

## 影響範囲
- 新規ワークスペース作成フロー
- Tauri コマンド/ブリッジ/フロントUI

## 判断理由
- フロントの即時バリデーションと Rust 側の最終チェックで不正入力を防ぐ

## 関連情報
- Issue #69
- Obsidian: Projects/Sheet Up/DESIGN/NewWorkspaceCreation.md

## 残課題 / フォローアップ
- Rust 側の単体テスト追加（必要なら別PRで対応）